### PR TITLE
Fix linting, modify base OAI harvester

### DIFF
--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -1,7 +1,6 @@
 # Classes for scrAPI Harvesters
 from __future__ import unicode_literals
 
-import os
 import time
 from dateutil.parser import parse
 from datetime import date, timedelta
@@ -31,7 +30,6 @@ class BaseHarvester(object):
             return element
         else:
             return unicode(element, encoding=encoding)
-
 
 
 class OAIHarvester(BaseHarvester):

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -33,6 +33,11 @@ class BaseHarvester(object):
 
 
 class OAIHarvester(BaseHarvester):
+    """ Create a harvester with a oai_dc namespace, in a date range.
+
+    Contains functions for harvesting from an OAI provider, normalizing,
+    and outputting in a way that scrapi can understand, in the most
+    generic terms possible. """
 
     NAMESPACES = {'dc': 'http://purl.org/dc/elements/1.1/',
                   'oai_dc': 'http://www.openarchives.org/OAI/2.0/',
@@ -98,8 +103,8 @@ class OAIHarvester(BaseHarvester):
         return records
 
     def get_contributors(self, result):
-        ''' this grabs all of the fields marked contributors
-        or creators in the OAI namespaces'''
+        """ this grabs all of the fields marked contributors
+        or creators in the OAI namespaces """
 
         contributors = result.xpath(
             '//dc:contributor/node()', namespaces=self.NAMESPACES) or ['']
@@ -154,17 +159,19 @@ class OAIHarvester(BaseHarvester):
         return {'serviceID': serviceID, 'url': self.copy_to_unicode(url), 'doi': self.copy_to_unicode(doi)}
 
     def get_properties(self, result, property_list):
-        ''' kwargs can be all of the properties in your particular
-        OAI harvester that does not fit into the standard schema '''
+        """ property_list should be all of the properties in your particular
+        OAI harvester that does not fit into the standard schema.
+
+        When you create a class, pass a list of properties to be
+        gathered in either the header or main body of the document,
+        that will then be included in the properties section """
 
         properties = {}
         for item in property_list:
             prop = (result.xpath('//dc:{}/node()'.format(item), namespaces=self.NAMESPACES) or [''])
             prop += (result.xpath('//ns0:{}/node()'.format(item), namespaces=self.NAMESPACES) or [''])
-            if len(prop) > 1:
-                properties[item] = prop
-            else:
-                properties[item] = prop[0]
+
+            properties[item] = prop if len(prop) > 1 else prop[0]
 
         return properties
 

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -179,12 +179,6 @@ class OAIHarvester(BaseHarvester):
 
         return properties
 
-    def get_date_created(self, result):
-        dates = (
-            result.xpath('//dc:date/node()', namespaces=self.NAMESPACES) or [''])
-        date = self.copy_to_unicode(dates[0])
-        return date
-
     def get_date_updated(self, result):
         dateupdated = result.xpath(
             '//ns0:header/ns0:datestamp/node()', namespaces=self.NAMESPACES)[0]
@@ -221,8 +215,7 @@ class OAIHarvester(BaseHarvester):
             'contributors': self.get_contributors(result),
             'tags': self.get_tags(result),
             'properties': self.get_properties(result, self.property_list),
-            'dateUpdated': self.get_date_updated(result),
-            'dateCreated': self.get_date_created(result)
+            'dateUpdated': self.get_date_updated(result)
         }
 
         return NormalizedDocument(payload)

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -48,26 +48,21 @@ class OAIHarvester(BaseHarvester):
 
     record_encoding = None
 
-    def __init__(self, name, base_url, property_list=None, approved_sets=None):
+    def __init__(self, name, base_url, timeout=0.5, property_list=None, approved_sets=None):
         self.name = name
         self.base_url = base_url
         self.property_list = property_list or ['date', 'language', 'type']
         self.approved_sets = approved_sets
+        self.timeout = timeout
 
     def harvest(self, days_back):
 
         start_date = str(date.today() - timedelta(int(days_back)))
 
         records_url = self.base_url + self.RECORDS_URL
-        initial_request_url = records_url + \
-            self.META_PREFIX_DATE.format(start_date)
+        request_url = records_url + self.META_PREFIX_DATE.format(start_date)
 
-        other_request_url = self.base_url + 'request' + self.RECORDS_URL + self.META_PREFIX_DATE.format(start_date)
-
-        records = self.get_records(initial_request_url, start_date)
-
-        if records == 'try a new url':
-            records = self.get_records(other_request_url, start_date)
+        records = self.get_records(request_url, start_date)
 
         rawdoc_list = []
         for record in records:
@@ -87,16 +82,13 @@ class OAIHarvester(BaseHarvester):
         print url
         data = requests.get(url)
 
-        try:
-            doc = etree.XML(data.content)
-        except etree.XMLSyntaxError:
-            return 'try a new url'
+        doc = etree.XML(data.content)
 
         records = doc.xpath('//ns0:record', namespaces=self.NAMESPACES)
         token = doc.xpath(
             '//ns0:resumptionToken/node()', namespaces=self.NAMESPACES)
         if len(token) == 1:
-            time.sleep(0.5)
+            time.sleep(self.timeout)
             base_url = url.replace(
                 self.META_PREFIX_DATE.format(start_date), '')
             base_url = base_url.replace(self.RESUMPTION + resump_token, '')
@@ -167,9 +159,8 @@ class OAIHarvester(BaseHarvester):
 
         properties = {}
         for item in property_list:
-            prop = (
-                result.xpath('//dc:{}/node()'.format(item), namespaces=self.NAMESPACES) or [''])
-
+            prop = (result.xpath('//dc:{}/node()'.format(item), namespaces=self.NAMESPACES) or [''])
+            prop += (result.xpath('//ns0:{}/node()'.format(item), namespaces=self.NAMESPACES) or [''])
             if len(prop) > 1:
                 properties[item] = prop
             else:
@@ -184,8 +175,7 @@ class OAIHarvester(BaseHarvester):
         return self.copy_to_unicode(date_updated)
 
     def get_title(self, result):
-        title = result.xpath(
-            '//dc:title/node()', namespaces=self.NAMESPACES)[0]
+        title = result.xpath('//dc:title/node()', namespaces=self.NAMESPACES)[0]
         return self.copy_to_unicode(title)
 
     def get_description(self, result):
@@ -197,12 +187,10 @@ class OAIHarvester(BaseHarvester):
         result = etree.XML(str_result)
 
         if self.approved_sets:
-            # load the list of approved series_names as a file
-
             set_spec = result.xpath('ns0:header/ns0:setSpec/node()', namespaces=self.NAMESPACES)[0]
-
-            if set_spec.replace('publication:', '') not in self.approved_sets:
-                print('Series not in approved list, not normalizing...')
+            set_spec_mod = set_spec.replace('publication:', '')
+            if set_spec_mod not in self.approved_sets:
+                print('Series {} not in approved list, not normalizing...').format(set_spec)
                 return None
 
         payload = {

--- a/scrapi/linter/__init__.py
+++ b/scrapi/linter/__init__.py
@@ -53,6 +53,8 @@ def lint(consume, normalize):
             raise TypeError("{} does not return type NormalizedDocument".format(consume))
         if doc and doc['id']['serviceID'] != raw_doc['docID']:
             raise ValueError('Serivce ID {} does not match {}'.format(doc['id']['serviceID'], raw_doc['docID']))
+        if doc and not doc['id']['url']:
+            raise ValueError('No url provided')
 
     output = [x for x in output if x]
     normalized_output = [x for x in normalized_output if x]

--- a/scrapi/linter/document.py
+++ b/scrapi/linter/document.py
@@ -1,4 +1,5 @@
 from scrapi.linter.util import lint
+from scrapi.linter.util import truthy
 
 
 class BaseDocument(object):
@@ -52,7 +53,7 @@ class NormalizedDocument(BaseDocument):
         'suffix': unicode
     }
     ID_FIELD = {
-        'url': unicode,
+        'url': (truthy, unicode),
         'doi': unicode,
         'serviceID': unicode
     }

--- a/scrapi/linter/document.py
+++ b/scrapi/linter/document.py
@@ -64,6 +64,5 @@ class NormalizedDocument(BaseDocument):
         'source': unicode,
         'description': unicode,
         'tags': [unicode],
-        'dateUpdated': unicode,
-        'dateCreated': unicode
+        'dateUpdated': unicode
     }

--- a/scrapi/linter/util.py
+++ b/scrapi/linter/util.py
@@ -29,3 +29,10 @@ def pretty_isinstance(actual, expected, name):
         name = ''.join(["['{}']".format(x) for x in name.split(' ') if x])
         errmsg = 'Expected "root{name}" to be of type {expected} but found {actual}'
         raise TypeError(errmsg.format(**locals()))
+
+
+def truthy(actual, expected, name):
+    pretty_isinstance(actual, expected, name)
+
+    if not actual:
+        raise TypeError('Expected {name} to exist, but it does not').format(name=name)


### PR DESCRIPTION
Linting now should reject missing URLs! Modified base classes to accept more customized base urls, and added optional time between requests for providers of different sensitivities. Also allowed for properties to be pulled from the OAI header as well as from within the dc elements. 