### PR TITLE
Update base harvester

### DIFF
--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -221,7 +221,8 @@ class OAIHarvester(BaseHarvester):
     def get_title(self, result):
         title = result.xpath(
             '//dc:title/node()',
-            namespaces=self.NAMESPACES)
+            namespaces=self.NAMESPACES
+        ) or ['']
         return util.copy_to_unicode(title[0])
 
     def get_description(self, result):
@@ -262,4 +263,7 @@ class OAIHarvester(BaseHarvester):
             'dateUpdated': self.get_date_updated(result)
         }
 
+        import json
+        with open('results/{}_normalized_results.json'.format(payload['source']), 'a') as f:
+            f.write(json.dumps(payload, indent=4))
         return NormalizedDocument(payload)

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -256,7 +256,7 @@ class OAIHarvester(BaseHarvester):
                 logger.info('Series {} not in approved list'.format(set_spec))
                 return None
 
-        payload = {
+        normalized = {
             'source': self.name,
             'title': self.get_title(result),
             'description': self.get_description(result),
@@ -267,8 +267,9 @@ class OAIHarvester(BaseHarvester):
             'dateUpdated': self.get_date_updated(result)
         }
 
-        if (result.xpath('ns0:header/@status', namespaces=self.NAMESPACES) or [''])[0] == 'deleted':
-            logger.info('Deleted record, not normalizing {}'.format(payload['id']['serviceID']))
+        status = result.xpath('ns0:header/@status', namespaces=self.NAMESPACES)
+        if status and status[0] == 'deleted':
+            logger.info('Deleted record, not normalizing {}'.format(normalized['id']['serviceID']))
             return None
 
-        return NormalizedDocument(payload)
+        return NormalizedDocument(normalized)

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -247,9 +247,8 @@ class OAIHarvester(BaseHarvester):
                 item_mod = item.replace('publication:', '')
                 if item_mod in self.approved_sets:
                     approved = True
-                else:
-                    logger.info('Series {} not in approved list'.format(item))
             if not approved:
+                logger.info('Series {} not in approved list'.format(item))
                 return None
 
         payload = {

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -242,13 +242,8 @@ class OAIHarvester(BaseHarvester):
                 'ns0:header/ns0:setSpec/node()',
                 namespaces=self.NAMESPACES
             )
-            approved = False
-            for item in set_spec:
-                item_mod = item.replace('publication:', '')
-                if item_mod in self.approved_sets:
-                    approved = True
-            if not approved:
-                logger.info('Series {} not in approved list'.format(item))
+            if not set([x.replace('publication:', '') for x in set_spec]).intersection(self.approved_sets):
+                logger.info('Series {} not in approved list'.format(set_spec))
                 return None
 
         payload = {
@@ -265,5 +260,7 @@ class OAIHarvester(BaseHarvester):
         if (result.xpath('ns0:header/@status', namespaces=self.NAMESPACES) or [''])[0] == 'deleted':
             logger.info('Deleted record, not normalizing {}'.format(payload['id']['serviceID']))
             return None
-
+        import json
+        with open('results/{}_normalized_results.json'.format(payload['source']), 'a') as f:
+            f.write(json.dumps(payload, indent=4))
         return NormalizedDocument(payload)

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -166,6 +166,13 @@ class OAIHarvester(BaseHarvester):
         return [util.copy_to_unicode(tag.lower().strip()) for tag in tags]
 
     def get_ids(self, result, doc):
+        """
+        Gather the DOI and url from identifiers, if possible.
+        Tries to save the DOI alone without a url extension.
+        Tries to save a link to the original content at the source,
+        instead of direct to a PDF, which is usually linked with viewcontent.cgi?
+        in the url field
+        """
         serviceID = doc.get('docID')
         identifiers = result.xpath(
             '//dc:identifier/node()', namespaces=self.NAMESPACES)
@@ -179,7 +186,8 @@ class OAIHarvester(BaseHarvester):
                 doi = doi.replace('http://dx.doi.org/', '')
                 doi = doi.strip(' ')
             if 'http://' in item or 'https://' in item:
-                url = item
+                if 'viewcontent' not in item:
+                    url = item
 
         return {
             'serviceID': serviceID,

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -268,7 +268,5 @@ class OAIHarvester(BaseHarvester):
         if (result.xpath('ns0:header/@status', namespaces=self.NAMESPACES) or [''])[0] == 'deleted':
             logger.info('Deleted record, not normalizing {}'.format(payload['id']['serviceID']))
             return None
-        import json
-        with open('results/{}_normalized_results.json'.format(payload['source']), 'a') as f:
-            f.write(json.dumps(payload, indent=4))
+
         return NormalizedDocument(payload)

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -263,7 +263,8 @@ class OAIHarvester(BaseHarvester):
             'dateUpdated': self.get_date_updated(result)
         }
 
-        import json
-        with open('results/{}_normalized_results.json'.format(payload['source']), 'a') as f:
-            f.write(json.dumps(payload, indent=4))
+        if (result.xpath('ns0:header/@status', namespaces=self.NAMESPACES) or [''])[0] == 'deleted':
+            logger.info('Deleted record, not normalizing {}'.format(payload['id']['serviceID']))
+            return None
+
         return NormalizedDocument(payload)

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -252,7 +252,7 @@ class OAIHarvester(BaseHarvester):
             )
             # check if there's an intersection between the approved sets and the
             # setSpec list provided in the record. If there isn't, don't normalize.
-            if not set([x.replace('publication:', '') for x in set_spec]).intersection(self.approved_sets):
+            if not {x.replace('publication:', '') for x in set_spec}.intersection(self.approved_sets):
                 logger.info('Series {} not in approved list'.format(set_spec))
                 return None
 

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -250,6 +250,8 @@ class OAIHarvester(BaseHarvester):
                 'ns0:header/ns0:setSpec/node()',
                 namespaces=self.NAMESPACES
             )
+            # check if there's an intersection between the approved sets and the
+            # setSpec list provided in the record. If there isn't, don't normalize.
             if not set([x.replace('publication:', '') for x in set_spec]).intersection(self.approved_sets):
                 logger.info('Series {} not in approved list'.format(set_spec))
                 return None


### PR DESCRIPTION
Blank titles are now set to empty string, and deleted records are not normalized (as they do not contain any information except for the service ID). Also, rejected sets are now only logged after all setSpecs in the header have been checked. 
