### PR TITLE
remove raw docstring of xml from doepages normalized record

### DIFF
--- a/scrapi/consumers/doepages/consumer.py
+++ b/scrapi/consumers/doepages/consumer.py
@@ -177,8 +177,7 @@ def normalize(raw_doc):
         'id': get_ids(doc, raw_doc),
         'source': NAME,
         'tags': get_tags(doc),
-        'dateUpdated': get_date_updated(doc),
-        'raw': raw_doc_string
+        'dateUpdated': get_date_updated(doc)
     }
     return NormalizedDocument(normalized_dict)
 


### PR DESCRIPTION
doepages had an extra 'raw' field in the normalized document that was a string of the whole raw xml record (probably left over from when we were experimenting with that...)

If a migration is run, we should remove those, maybe?