### PR TITLE
Add logging, and date published to properties

### DIFF
--- a/scrapi/consumers/figshare/consumer.py
+++ b/scrapi/consumers/figshare/consumer.py
@@ -4,22 +4,24 @@ Figshare harvester of public projects for the SHARE Notification Service
 Example API query: http://api.figshare.com/v1/articles/search?search_for=*&from_date=2015-2-1&end_date=2015-2-1
 """
 
-
 from __future__ import unicode_literals
-
 
 import time
 import json
+import logging
 from dateutil.parser import parse
 from datetime import date, timedelta
 
 import requests
 
-
 from nameparser import HumanName
 
 from scrapi.linter import lint
 from scrapi.linter.document import RawDocument, NormalizedDocument
+
+logging.basicConfig(level=logging.INFO)
+
+logger = logging.getLogger(__name__)
 
 NAME = 'figshare'
 URL = 'http://api.figshare.com/v1/articles/search?search_for=*&from_date='
@@ -63,6 +65,7 @@ def get_records(search_url):
 
     all_records = []
     while len(all_records) < total_records:
+        logger.info('Requesting records for url: {}&page={}'.format(search_url, str(page)))
         record_list = records.json()['items']
 
         for record in record_list:

--- a/scrapi/consumers/figshare/consumer.py
+++ b/scrapi/consumers/figshare/consumer.py
@@ -21,8 +21,6 @@ from nameparser import HumanName
 from scrapi.linter import lint
 from scrapi.linter.document import RawDocument, NormalizedDocument
 
-logging.basicConfig(level=logging.INFO)
-
 logger = logging.getLogger(__name__)
 
 NAME = 'figshare'

--- a/scrapi/consumers/figshare/consumer.py
+++ b/scrapi/consumers/figshare/consumer.py
@@ -123,7 +123,8 @@ def get_properties(record):
         'defined_type': record['defined_type'],
         'type': record['type'],
         'links': record['links'],
-        'doi': record['DOI']
+        'doi': record['DOI'],
+        'publishedDate': record['published_date']
     }
 
 

--- a/scrapi/consumers/figshare/consumer.py
+++ b/scrapi/consumers/figshare/consumer.py
@@ -1,5 +1,7 @@
 """
 Figshare harvester of public projects for the SHARE Notification Service
+Note: At the moment, this harvester only harvests basic data on each article, and does
+not make a seperate request for additional metadata for each record.
 
 Example API query: http://api.figshare.com/v1/articles/search?search_for=*&from_date=2015-2-1&end_date=2015-2-1
 """


### PR DESCRIPTION
Figshare was not saving date_published, most likely because I removed it and forgot to move it to properties. when we decided to only show dateUpdated in the main schema. Date published is now saved to properties.