### PR TITLE
More 0.6 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ install:
 
 before_script: flake8 .
 
-script: invoke test
+script:
+  - invoke provider_map
+  - invoke test
 
 after_success:
   coveralls

--- a/scrapi/util.py
+++ b/scrapi/util.py
@@ -1,4 +1,3 @@
-import six
 from datetime import datetime
 
 import pytz
@@ -20,10 +19,9 @@ def copy_to_unicode(element):
         for idx, item in enumerate(element):
             element[idx] = copy_to_unicode(item)
     else:
-        element = ''.join(element)
         try:
-            element = six.u(element)
-        except (TypeError, UnicodeDecodeError):
+            element = u''.join(element)
+        except TypeError:
             pass
     return element
 

--- a/scrapi/util.py
+++ b/scrapi/util.py
@@ -20,6 +20,7 @@ def copy_to_unicode(element):
             element[idx] = copy_to_unicode(item)
     else:
         try:
+            # A dirty way to convert to unicode in python 2 + 3.3+
             element = u''.join(element)
         except TypeError:
             pass

--- a/scrapi/util.py
+++ b/scrapi/util.py
@@ -23,7 +23,7 @@ def copy_to_unicode(element):
         element = ''.join(element)
         try:
             element = six.u(element)
-        except TypeError:
+        except (TypeError, UnicodeDecodeError):
             pass
     return element
 

--- a/scripts/delete.py
+++ b/scripts/delete.py
@@ -1,0 +1,26 @@
+import logging
+
+from scripts.util import documents
+
+from scrapi import settings
+from scrapi.processing.elasticsearch import es
+
+logger = logging.getLogger(__name__)
+
+
+def delete_by_source(source):
+    count = 0
+    exceptions = []
+    for doc in documents(source):
+        count += 1
+        try:
+            doc.delete()
+            es.delete(index=settings.ELASTIC_INDEX, doc_type=source, id=doc.docID, ignore=[404])
+            es.delete(index='share_v1', doc_type=source, id=doc.docID, ignore=[404])
+        except Exception as e:
+            logger.exception(e)
+            exceptions.append(e)
+
+    for ex in exceptions:
+        logger.exception(e)
+    logger.info('{} documents processed, with {} exceptions'.format(count, len(exceptions)))

--- a/scripts/rename.py
+++ b/scripts/rename.py
@@ -35,8 +35,9 @@ def rename(source, target, dry=True):
             exceptions.append(e)
         else:
             if not dry:
-                doc.delete()
+                # doc.delete()
                 es.delete(index=settings.ELASTIC_INDEX, doc_type=source, id=raw['docID'], ignore=[404])
+                es.delete(index='share_v1', doc_type=source, id=raw['docID'], ignore=[404])
             logger.info('Deleted document from {} with id {}'.format(source, raw['docID']))
     if dry:
         logger.info('Dry run complete')

--- a/scripts/rename.py
+++ b/scripts/rename.py
@@ -35,7 +35,6 @@ def rename(source, target, dry=True):
             exceptions.append(e)
         else:
             if not dry:
-                # doc.delete()
                 es.delete(index=settings.ELASTIC_INDEX, doc_type=source, id=raw['docID'], ignore=[404])
                 es.delete(index='share_v1', doc_type=source, id=raw['docID'], ignore=[404])
             logger.info('Deleted document from {} with id {}'.format(source, raw['docID']))

--- a/tasks.py
+++ b/tasks.py
@@ -160,7 +160,7 @@ def lint(name):
 @task
 def provider_map():
     from scrapi.processing.elasticsearch import es
-    es.indices.delete(index='share_providers', ignore=['404'])
+    es.indices.delete(index='share_providers', ignore=[404])
 
     for harvester_name, harvester in registry.items():
         es.index(

--- a/tasks.py
+++ b/tasks.py
@@ -45,6 +45,12 @@ def rename(source, target, dry=True):
 
 
 @task
+def delete(source):
+    from scripts.delete import delete_by_source
+    delete_by_source(source)
+
+
+@task
 def reset_search():
     run("curl -XPOST 'http://localhost:9200/_shutdown'")
     if platform.linux_distribution()[0] == 'Ubuntu':


### PR DESCRIPTION
- Run provider map in tests.
- Ignore unicode-decode errors in copy_to_unicode
- Don't delete documents from cassandra (yet), do delete them from all elasticsearch indices.
- Delete old provider map before making a new one
- Add delete task