### PR TITLE
Add date range to all harvesters 

### DIFF
--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -141,8 +141,8 @@ class OAIHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().isoformat()
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().isoformat()
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().isoformat() if start_date else (date.today() - timedelta(1)).isoformat()
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().isoformat() if end_date else date.today().isoformat()
 
         if self.timezone_granularity:
             start_date += 'T00:00:00Z'

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -141,8 +141,8 @@ class OAIHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().isoformat() if start_date else (date.today() - timedelta(1)).isoformat()
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().isoformat() if end_date else date.today().isoformat()
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().isoformat()
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().isoformat()
 
         if self.timezone_granularity:
             start_date += 'T00:00:00Z'

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -141,8 +141,8 @@ class OAIHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = start_date.isoformat() if start_date else (date.today() - timedelta(1)).isoformat()
-        end_date = end_date.isoformat() if end_date else date.today().isoformat()
+        start_date = (start_date or date.today() - timedelta(1)).isoformat()
+        end_date = (end_date or date.today()).isoformat()
 
         if self.timezone_granularity:
             start_date += 'T00:00:00Z'

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import abc
 import json
 import logging
-from datetime import datetime, timedelta, date
+from datetime import timedelta, date
 
 from lxml import etree
 
@@ -56,7 +56,7 @@ class BaseHarvester(object):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def harvest(self, days_back=1):
+    def harvest(self, start_date=None, end_date=None):
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -141,8 +141,8 @@ class OAIHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().isoformat() if start_date else (date.today() - timedelta(1)).isoformat()
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().isoformat() if end_date else date.today().isoformat()
+        start_date = start_date.isoformat() if start_date else (date.today() - timedelta(1)).isoformat()
+        end_date = end_date.isoformat() if end_date else date.today().isoformat()
 
         if self.timezone_granularity:
             start_date += 'T00:00:00Z'

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import abc
 import json
 import logging
+from datetime import datetime, timedelta, date
 
 from lxml import etree
 
@@ -138,7 +139,10 @@ class OAIHarvester(XMLHarvester):
         ret = dc + ns0
         return ret[0] if len(ret) == 1 else ret
 
-    def harvest(self, start_date, end_date):
+    def harvest(self, start_date=None, end_date=None):
+
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().isoformat() if start_date else (date.today() - timedelta(1)).isoformat()
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().isoformat() if end_date else date.today().isoformat()
 
         if self.timezone_granularity:
             start_date += 'T00:00:00Z'

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -141,7 +141,7 @@ class OAIHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = (start_date or date.today() - timedelta(1)).isoformat()
+        start_date = (start_date or date.today() - timedelta(settings.DAYS_BACK)).isoformat()
         end_date = (end_date or date.today()).isoformat()
 
         if self.timezone_granularity:

--- a/scrapi/events.py
+++ b/scrapi/events.py
@@ -101,32 +101,14 @@ def logged(event, index=None):
 
 
 def extract_context(func, *args, **kwargs):
-    args = list(reversed(args))
     arginfo = inspect.getargspec(func)
-
-    if arginfo.defaults:
-        arg_names = arginfo.args[:len(arginfo.defaults) - 1]
-        kwarg_names = arginfo.args[len(arginfo.defaults) - 1:]
-    else:
-        kwarg_names = []
-        arg_names = arginfo.args
-
-    real_args = {
-        key: kwargs.pop(key, val)
-        for key, val
-        in zip(kwarg_names, arginfo.defaults or [])
+    arg_names = arginfo.args
+    defaults = {
+        arg_names.pop(-1): kwarg
+        for kwarg in (arginfo.defaults or [])
     }
 
-    for name in arg_names:
-        real_args[name] = args.pop()
-
-    if arginfo.varargs:
-        real_args[arginfo.varargs] = list(reversed(args))
-
-    if arginfo.keywords:
-        real_args[arginfo.keywords] = kwargs
-
-    return real_args
+    return dict(zip(arg_names, args), **dict(defaults, **kwargs))
 
 
 def creates_task(event):

--- a/scrapi/events.py
+++ b/scrapi/events.py
@@ -108,7 +108,14 @@ def extract_context(func, *args, **kwargs):
         for kwarg in (arginfo.defaults or [])
     }
 
-    return dict(zip(arg_names, args), **dict(defaults, **kwargs))
+    computed_args = zip(arg_names, args)
+    if arginfo.varargs:
+        computed_args.append(('args', list(args[len(arg_names):])))
+
+    if kwargs:
+        defaults['kwargs'] = kwargs
+
+    return dict(computed_args, **defaults)
 
 
 def creates_task(event):

--- a/scrapi/harvesters/biomedcentral.py
+++ b/scrapi/harvesters/biomedcentral.py
@@ -88,7 +88,7 @@ class BiomedCentralHarvester(JSONHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date() if start_date else (date.today() - timedelta(1))
+        start_date = start_date or (date.today() - timedelta(1))
 
         # Biomed central can only have a start date
         end_date = date.today()

--- a/scrapi/harvesters/biomedcentral.py
+++ b/scrapi/harvesters/biomedcentral.py
@@ -10,7 +10,7 @@ from __future__ import unicode_literals
 
 import json
 import logging
-import datetime
+from datetime import date, datetime, timedelta
 from dateutil.parser import parse
 
 from nameparser import HumanName
@@ -86,12 +86,12 @@ class BiomedCentralHarvester(JSONHarvester):
             )
         }
 
-    def harvest(self, start_date, end_date):
+    def harvest(self, start_date=None, end_date=None):
 
-        start_date = datetime.datetime.strptime(start_date, '%Y-%m-%d').date()
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date() if start_date else (date.today() - timedelta(1))
 
         # Biomed central can only have a start date
-        end_date = datetime.date.today()
+        end_date = date.today()
         date_number = end_date - start_date
 
         search_url = self.URL.format(date_number.days)
@@ -115,7 +115,7 @@ class BiomedCentralHarvester(JSONHarvester):
         return record_list
 
     def get_records(self, search_url):
-        records = requests.get(search_url + "#{}".format(datetime.date.today()))
+        records = requests.get(search_url + "#{}".format(date.today()))
         page = 1
 
         all_records = []
@@ -127,7 +127,7 @@ class BiomedCentralHarvester(JSONHarvester):
                 all_records.append(record)
 
             page += 1
-            records = requests.get(search_url + '&page={}#{}'.format(str(page), datetime.date.today()), throttle=10)
+            records = requests.get(search_url + '&page={}#{}'.format(str(page), date.today()), throttle=10)
             current_records = len(records.json()['entries'])
 
         return all_records

--- a/scrapi/harvesters/biomedcentral.py
+++ b/scrapi/harvesters/biomedcentral.py
@@ -16,6 +16,7 @@ from dateutil.parser import parse
 from nameparser import HumanName
 
 from scrapi import requests
+from scrapi import settings
 from scrapi.base import JSONHarvester
 from scrapi.linter.document import RawDocument
 from scrapi.base.helpers import build_properties
@@ -88,7 +89,7 @@ class BiomedCentralHarvester(JSONHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = start_date or (date.today() - timedelta(1))
+        start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
 
         # Biomed central can only have a start date
         end_date = date.today()

--- a/scrapi/harvesters/biomedcentral.py
+++ b/scrapi/harvesters/biomedcentral.py
@@ -86,8 +86,15 @@ class BiomedCentralHarvester(JSONHarvester):
             )
         }
 
-    def harvest(self, days_back=1):
-        search_url = self.URL.format(days_back)
+    def harvest(self, start_date, end_date):
+
+        start_date = datetime.datetime.strptime(start_date, '%Y-%m-%d').date()
+
+        # Biomed central can only have a start date
+        end_date = datetime.date.today()
+        date_number = end_date - start_date
+
+        search_url = self.URL.format(date_number.days)
         records = self.get_records(search_url)
 
         record_list = []

--- a/scrapi/harvesters/biomedcentral.py
+++ b/scrapi/harvesters/biomedcentral.py
@@ -10,7 +10,7 @@ from __future__ import unicode_literals
 
 import json
 import logging
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 from dateutil.parser import parse
 
 from nameparser import HumanName

--- a/scrapi/harvesters/clinicaltrials.py
+++ b/scrapi/harvesters/clinicaltrials.py
@@ -11,7 +11,7 @@ from __future__ import unicode_literals
 
 import time
 import logging
-import datetime
+from datetime import datetime, date
 
 from lxml import etree
 
@@ -95,25 +95,25 @@ class ClinicalTrialsHarvester(XMLHarvester):
     def namespaces(self):
         return None
 
-    def harvest(self, days_back=1):
+    def harvest(self, start_date=None, end_date=None):
         """ First, get a list of all recently updated study urls,
         then get the xml one by one and save it into a list
         of docs including other information """
 
-        today = datetime.date.today()
-        start_date = today - datetime.timedelta(days_back)
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date() if start_date else (date.today() - timedelta(1))
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date() if end_date else date.today()
 
-        month = today.strftime('%m')
-        day = today.strftime('%d')
-        year = today.strftime('%Y')
+        end_month = end_date.strftime('%m')
+        end_day = end_date.strftime('%d')
+        end_year = end_date.strftime('%Y')
 
-        y_month = start_date.strftime('%m')
-        y_day = start_date.strftime('%d')
-        y_year = start_date.strftime('%Y')
+        start_month = start_date.strftime('%m')
+        start_day = start_date.strftime('%d')
+        start_year = start_date.strftime('%Y')
 
         base_url = 'http://clinicaltrials.gov/ct2/results?lup_s='
         url_end = '{}%2F{}%2F{}%2F&lup_e={}%2F{}%2F{}&displayxml=true'.\
-            format(y_month, y_day, y_year, month, day, year)
+            format(start_month, start_day, start_year, end_month, end_day, end_year)
 
         url = base_url + url_end
 

--- a/scrapi/harvesters/clinicaltrials.py
+++ b/scrapi/harvesters/clinicaltrials.py
@@ -100,7 +100,7 @@ class ClinicalTrialsHarvester(XMLHarvester):
         then get the xml one by one and save it into a list
         of docs including other information """
 
-        start_date = start_date or (date.today() - timedelta(1))
+        start_date = start_date or date.today() - timedelta(1)
         end_date = end_date or date.today()
 
         end_month = end_date.strftime('%m')

--- a/scrapi/harvesters/clinicaltrials.py
+++ b/scrapi/harvesters/clinicaltrials.py
@@ -11,7 +11,7 @@ from __future__ import unicode_literals
 
 import time
 import logging
-from datetime import datetime, date
+from datetime import datetime, date, timedelta
 
 from lxml import etree
 

--- a/scrapi/harvesters/clinicaltrials.py
+++ b/scrapi/harvesters/clinicaltrials.py
@@ -18,6 +18,7 @@ from lxml import etree
 from dateutil.parser import *
 
 from scrapi import requests
+from scrapi import settings
 from scrapi.base import XMLHarvester
 from scrapi.util import copy_to_unicode
 from scrapi.linter.document import RawDocument
@@ -100,7 +101,7 @@ class ClinicalTrialsHarvester(XMLHarvester):
         then get the xml one by one and save it into a list
         of docs including other information """
 
-        start_date = start_date or date.today() - timedelta(1)
+        start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
         end_date = end_date or date.today()
 
         end_month = end_date.strftime('%m')

--- a/scrapi/harvesters/clinicaltrials.py
+++ b/scrapi/harvesters/clinicaltrials.py
@@ -11,7 +11,7 @@ from __future__ import unicode_literals
 
 import time
 import logging
-from datetime import datetime, date, timedelta
+from datetime import date, timedelta
 
 from lxml import etree
 

--- a/scrapi/harvesters/clinicaltrials.py
+++ b/scrapi/harvesters/clinicaltrials.py
@@ -100,8 +100,8 @@ class ClinicalTrialsHarvester(XMLHarvester):
         then get the xml one by one and save it into a list
         of docs including other information """
 
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date() if start_date else (date.today() - timedelta(1))
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date() if end_date else date.today()
+        start_date = start_date or (date.today() - timedelta(1))
+        end_date = end_date or date.today()
 
         end_month = end_date.strftime('%m')
         end_day = end_date.strftime('%d')

--- a/scrapi/harvesters/crossref.py
+++ b/scrapi/harvesters/crossref.py
@@ -11,7 +11,7 @@ from __future__ import unicode_literals
 import json
 import logging
 
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 
 from nameparser import HumanName
 from dateutil.parser import parse
@@ -83,9 +83,11 @@ class CrossRefHarvester(JSONHarvester):
             )
         }
 
-    def harvest(self, days_back=0):
-        start_date = date.today() - timedelta(days_back)
-        base_url = 'http://api.crossref.org/v1/works?filter=from-pub-date:{},until-pub-date:{}&rows={{}}&offset={{}}'.format(str(start_date), str(date.today()))
+    def harvest(self, start_date=None, end_date=None):
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().isoformat() if start_date else (date.today() - timedelta(1)).isoformat()
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().isoformat() if end_date else date.today().isoformat()
+
+        base_url = 'http://api.crossref.org/v1/works?filter=from-pub-date:{},until-pub-date:{}&rows={{}}&offset={{}}'.format(start_date, end_date)
         total = requests.get(base_url.format('0', '0')).json()['message']['total-results']
         logger.info('{} documents to be harvested'.format(total))
 

--- a/scrapi/harvesters/crossref.py
+++ b/scrapi/harvesters/crossref.py
@@ -11,12 +11,13 @@ from __future__ import unicode_literals
 import json
 import logging
 
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta
 
 from nameparser import HumanName
 from dateutil.parser import parse
 
 from scrapi import requests
+from scrapi import settings
 from scrapi.base import JSONHarvester
 from scrapi.base.helpers import build_properties
 from scrapi.linter.document import RawDocument
@@ -84,7 +85,7 @@ class CrossRefHarvester(JSONHarvester):
         }
 
     def harvest(self, start_date=None, end_date=None):
-        start_date = start_date or date.today() - timedelta(1)
+        start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
         end_date = end_date or date.today()
 
         base_url = 'http://api.crossref.org/v1/works?filter=from-pub-date:{},until-pub-date:{}&rows={{}}&offset={{}}'.format(start_date.isoformat(), end_date.isoformat())

--- a/scrapi/harvesters/crossref.py
+++ b/scrapi/harvesters/crossref.py
@@ -84,10 +84,10 @@ class CrossRefHarvester(JSONHarvester):
         }
 
     def harvest(self, start_date=None, end_date=None):
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().isoformat() if start_date else (date.today() - timedelta(1)).isoformat()
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().isoformat() if end_date else date.today().isoformat()
+        start_date = start_date or date.today() - timedelta(1)
+        end_date = end_date or date.today()
 
-        base_url = 'http://api.crossref.org/v1/works?filter=from-pub-date:{},until-pub-date:{}&rows={{}}&offset={{}}'.format(start_date, end_date)
+        base_url = 'http://api.crossref.org/v1/works?filter=from-pub-date:{},until-pub-date:{}&rows={{}}&offset={{}}'.format(start_date.isoformat(), end_date.isoformat())
         total = requests.get(base_url.format('0', '0')).json()['message']['total-results']
         logger.info('{} documents to be harvested'.format(total))
 

--- a/scrapi/harvesters/dataone.py
+++ b/scrapi/harvesters/dataone.py
@@ -157,8 +157,8 @@ class DataOneHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().isoformat() if start_date else (date.today() - timedelta(1)).isoformat()
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().isoformat() if end_date else date.today().isoformat()
+        start_date = start_date or (date.today() - timedelta(1))
+        end_date = end_date or date.today()
 
         records = self.get_records(start_date, end_date)
 
@@ -180,7 +180,7 @@ class DataOneHarvester(XMLHarvester):
         API, with the specified number of rows.
         Returns an etree element with results '''
 
-        query = 'dateModified:[{}T00:00:00Z TO {}T00:00:00Z]'.format(start_date, end_date)
+        query = 'dateModified:[{}T00:00:00Z TO {}T00:00:00Z]'.format(start_date.isoformat(), end_date.isoformat())
         doc = requests.get(DATAONE_SOLR_ENDPOINT, params={
             'q': query,
             'start': 0,

--- a/scrapi/harvesters/dataone.py
+++ b/scrapi/harvesters/dataone.py
@@ -156,7 +156,7 @@ class DataOneHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = start_date or (date.today() - timedelta(1))
+        start_date = start_date or date.today() - timedelta(1)
         end_date = end_date or date.today()
 
         records = self.get_records(start_date, end_date)

--- a/scrapi/harvesters/dataone.py
+++ b/scrapi/harvesters/dataone.py
@@ -11,7 +11,7 @@ import re
 
 import logging
 from datetime import datetime
-from datetime import timedelta
+from datetime import timedelta, date
 
 from lxml import etree
 from dateutil.parser import *

--- a/scrapi/harvesters/dataone.py
+++ b/scrapi/harvesters/dataone.py
@@ -155,8 +155,12 @@ class DataOneHarvester(XMLHarvester):
         'description': ("str[@name='abstract']/node()", single_result)
     }
 
-    def harvest(self, days_back=1):
-        records = self.get_records(days_back)
+    def harvest(self, start_date=None, end_date=None):
+
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().isoformat() if start_date else (date.today() - timedelta(1)).isoformat()
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().isoformat() if end_date else date.today().isoformat()
+
+        records = self.get_records(start_date, end_date)
 
         xml_list = []
         for record in records:
@@ -171,17 +175,12 @@ class DataOneHarvester(XMLHarvester):
 
         return xml_list
 
-    def get_records(self, days_back):
+    def get_records(self, start_date, end_date):
         ''' helper function to get a response from the DataONE
         API, with the specified number of rows.
         Returns an etree element with results '''
-        to_date = datetime.utcnow()
-        from_date = (datetime.utcnow() - timedelta(days=days_back))
 
-        to_date = to_date.replace(hour=0, minute=0, second=0, microsecond=0)
-        from_date = from_date.replace(hour=0, minute=0, second=0, microsecond=0)
-
-        query = 'dateModified:[{}Z TO {}Z]'.format(from_date.isoformat(), to_date.isoformat())
+        query = 'dateModified:[{}T00:00:00Z TO {}T00:00:00Z]'.format(start_date, end_date)
         doc = requests.get(DATAONE_SOLR_ENDPOINT, params={
             'q': query,
             'start': 0,

--- a/scrapi/harvesters/dataone.py
+++ b/scrapi/harvesters/dataone.py
@@ -19,6 +19,7 @@ from xml.etree import ElementTree
 from nameparser import HumanName
 
 from scrapi import requests
+from scrapi import settings
 from scrapi.base import XMLHarvester
 from scrapi.util import copy_to_unicode
 from scrapi.linter.document import RawDocument
@@ -156,7 +157,7 @@ class DataOneHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = start_date or date.today() - timedelta(1)
+        start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
         end_date = end_date or date.today()
 
         records = self.get_records(start_date, end_date)

--- a/scrapi/harvesters/dataone.py
+++ b/scrapi/harvesters/dataone.py
@@ -10,7 +10,6 @@ from __future__ import unicode_literals
 import re
 
 import logging
-from datetime import datetime
 from datetime import timedelta, date
 
 from lxml import etree

--- a/scrapi/harvesters/doepages.py
+++ b/scrapi/harvesters/doepages.py
@@ -26,11 +26,11 @@ class DoepagesHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().strftime('%m/%d/%Y') if start_date else date.today().strftime('%m/%d/%Y')
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().strftime('%m/%d/%Y') if end_date else (date.today() - timedelta(1)).strftime('%m/%d/%Y')
+        start_date = start_date or date.today()
+        end_date = end_date or date.today() - timedelta(1)
 
         base_url = 'http://www.osti.gov/pages/pagesxml?nrows={0}&EntryDateFrom={1}&EntryDateTo={2}'
-        url = base_url.format('1', start_date, end_date)
+        url = base_url.format('1', start_date.strftime('%m/%d/%Y'), end_date.strftime('%m/%d/%Y'))
         initial_data = requests.get(url)
         record_encoding = initial_data.encoding
         initial_doc = etree.XML(initial_data.content)

--- a/scrapi/harvesters/doepages.py
+++ b/scrapi/harvesters/doepages.py
@@ -26,18 +26,19 @@ class DoepagesHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date() if start_date else (date.today() - timedelta(1))
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date() if end_date else date.today()
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().strftime('%m/%d/%Y')
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().strftime('%m/%d/%Y')
 
         base_url = 'http://www.osti.gov/pages/pagesxml?nrows={0}&EntryDateFrom={1}&EntryDateTo={2}'
-        url = base_url.format('1', start_date.strftime('%m/%d/%Y'), end_date.strftime('%m/%d/%Y'))
+        url = base_url.format('1', start_date, end_date)
         initial_data = requests.get(url)
         record_encoding = initial_data.encoding
         initial_doc = etree.XML(initial_data.content)
 
         num_results = int(initial_doc.xpath('//records/@count', namespaces=self.namespaces)[0])
 
-        url = base_url.format(num_results, start_date.strftime('%m/%d/%Y'), end_date.strftime('%m/%d/%Y'))
+        url = base_url.format(num_results, start_date, end_date)
+
         data = requests.get(url)
         doc = etree.XML(data.content)
 

--- a/scrapi/harvesters/doepages.py
+++ b/scrapi/harvesters/doepages.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta
 
 from lxml import etree
 

--- a/scrapi/harvesters/doepages.py
+++ b/scrapi/harvesters/doepages.py
@@ -26,8 +26,8 @@ class DoepagesHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = start_date or date.today()
-        end_date = end_date or date.today() - timedelta(1)
+        start_date = start_date or date.today() - timedelta(1)
+        end_date = end_date or date.today()
 
         base_url = 'http://www.osti.gov/pages/pagesxml?nrows={0}&EntryDateFrom={1}&EntryDateTo={2}'
         url = base_url.format('1', start_date.strftime('%m/%d/%Y'), end_date.strftime('%m/%d/%Y'))

--- a/scrapi/harvesters/doepages.py
+++ b/scrapi/harvesters/doepages.py
@@ -26,8 +26,8 @@ class DoepagesHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().strftime('%m/%d/%Y')
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().strftime('%m/%d/%Y')
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().strftime('%m/%d/%Y') if start_date else date.today().strftime('%m/%d/%Y')
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().strftime('%m/%d/%Y') if end_date else (date.today() - timedelta(1)).strftime('%m/%d/%Y')
 
         base_url = 'http://www.osti.gov/pages/pagesxml?nrows={0}&EntryDateFrom={1}&EntryDateTo={2}'
         url = base_url.format('1', start_date, end_date)

--- a/scrapi/harvesters/doepages.py
+++ b/scrapi/harvesters/doepages.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 
 from lxml import etree
 
@@ -24,18 +24,20 @@ class DoepagesHarvester(XMLHarvester):
         'dcq': 'http://purl.org/dc/terms/'
     }
 
-    def harvest(self, days_back=1):
-        today = date.today()
-        start_date = today - timedelta(days_back)
+    def harvest(self, start_date=None, end_date=None):
+
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date() if start_date else (date.today() - timedelta(1))
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date() if end_date else date.today()
+
         base_url = 'http://www.osti.gov/pages/pagesxml?nrows={0}&EntryDateFrom={1}&EntryDateTo={2}'
-        url = base_url.format('1', start_date.strftime('%m/%d/%Y'), today.strftime('%m/%d/%Y'))
+        url = base_url.format('1', start_date.strftime('%m/%d/%Y'), end_date.strftime('%m/%d/%Y'))
         initial_data = requests.get(url)
         record_encoding = initial_data.encoding
         initial_doc = etree.XML(initial_data.content)
 
         num_results = int(initial_doc.xpath('//records/@count', namespaces=self.namespaces)[0])
 
-        url = base_url.format(num_results, start_date.strftime('%m/%d/%Y'), today.strftime('%m/%d/%Y'))
+        url = base_url.format(num_results, start_date.strftime('%m/%d/%Y'), end_date.strftime('%m/%d/%Y'))
         data = requests.get(url)
         doc = etree.XML(data.content)
 

--- a/scrapi/harvesters/doepages.py
+++ b/scrapi/harvesters/doepages.py
@@ -5,9 +5,10 @@ from datetime import date, timedelta
 from lxml import etree
 
 from scrapi import requests
+from scrapi import settings
 from scrapi.base import XMLHarvester
 from scrapi.linter import RawDocument
-from scrapi.util import copy_to_unicode
+from scrapi.util import copy_to_unicode, format_date_with_slashes
 from scrapi.base.schemas import DOESCHEMA
 
 
@@ -26,11 +27,11 @@ class DoepagesHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = start_date or date.today() - timedelta(1)
+        start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
         end_date = end_date or date.today()
 
         base_url = 'http://www.osti.gov/pages/pagesxml?nrows={0}&EntryDateFrom={1}&EntryDateTo={2}'
-        url = base_url.format('1', start_date.strftime('%m/%d/%Y'), end_date.strftime('%m/%d/%Y'))
+        url = base_url.format('1', format_date_with_slashes(start_date), format_date_with_slashes(end_date))
         initial_data = requests.get(url)
         record_encoding = initial_data.encoding
         initial_doc = etree.XML(initial_data.content)

--- a/scrapi/harvesters/figshare.py
+++ b/scrapi/harvesters/figshare.py
@@ -11,7 +11,7 @@ from __future__ import unicode_literals
 import json
 import logging
 from dateutil.parser import parse
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 
 
 from scrapi import requests
@@ -49,21 +49,18 @@ class FigshareHarvester(JSONHarvester):
         )
     }
 
-    def harvest(self, days_back=1):
+    def harvest(self, start_date=None, end_date=None):
         """ Figshare should always have a 24 hour delay because they
         manually go through and check for test projects. Most of them
         are removed within 24 hours.
         """
-        start_date = date.today() - timedelta(days_back) - timedelta(1)
-        to_date = start_date + timedelta(1)
-        search_url = '{0}{1}-{2}-{3}&to_date={4}-{5}-{6}'.format(
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date() - timedelta(1)
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date() - timedelta(1)
+
+        search_url = '{0}{1}&to_date={2}'.format(
             self.URL,
-            start_date.year,
-            start_date.month,
-            start_date.day,
-            to_date.year,
-            to_date.month,
-            to_date.day
+            start_date,
+            end_date
         )
 
         records = self.get_records(search_url)

--- a/scrapi/harvesters/figshare.py
+++ b/scrapi/harvesters/figshare.py
@@ -54,8 +54,8 @@ class FigshareHarvester(JSONHarvester):
         manually go through and check for test projects. Most of them
         are removed within 24 hours.
         """
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date() - timedelta(1)
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date() - timedelta(1)
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date() - timedelta(1) if start_date else date.today().isoformat()
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date() - timedelta(1) if end_date else (date.today() - timedelta(1)).isoformat()
 
         search_url = '{0}{1}&to_date={2}'.format(
             self.URL,

--- a/scrapi/harvesters/figshare.py
+++ b/scrapi/harvesters/figshare.py
@@ -15,6 +15,7 @@ from datetime import date, timedelta
 
 
 from scrapi import requests
+from scrapi import settings
 from scrapi.base import JSONHarvester
 from scrapi.linter.document import RawDocument
 from scrapi.base.helpers import default_name_parser, build_properties
@@ -57,7 +58,7 @@ class FigshareHarvester(JSONHarvester):
         So, we will shift everything back a day with harvesting to ensure
         nothing is harvested on the day of.
         """
-        start_date = start_date - timedelta(1) if start_date else date.today() - timedelta(2)
+        start_date = start_date - timedelta(1) if start_date else date.today() - timedelta(1 + settings.DAYS_BACK)
         end_date = end_date - timedelta(1) if end_date else date.today() - timedelta(1)
 
         search_url = '{0}{1}&to_date={2}'.format(

--- a/scrapi/harvesters/figshare.py
+++ b/scrapi/harvesters/figshare.py
@@ -11,7 +11,7 @@ from __future__ import unicode_literals
 import json
 import logging
 from dateutil.parser import parse
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta
 
 
 from scrapi import requests

--- a/scrapi/harvesters/figshare.py
+++ b/scrapi/harvesters/figshare.py
@@ -54,13 +54,13 @@ class FigshareHarvester(JSONHarvester):
         manually go through and check for test projects. Most of them
         are removed within 24 hours.
         """
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date() - timedelta(1) if start_date else date.today().isoformat()
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date() - timedelta(1) if end_date else (date.today() - timedelta(1)).isoformat()
+        start_date = start_date - timedelta(1) if start_date else date.today() - timedelta(2)
+        end_date = end_date - timedelta(1) if end_date else (date.today() - timedelta(1))
 
         search_url = '{0}{1}&to_date={2}'.format(
             self.URL,
-            start_date,
-            end_date
+            start_date.isoformat(),
+            end_date.isoformat()
         )
 
         records = self.get_records(search_url)

--- a/scrapi/harvesters/figshare.py
+++ b/scrapi/harvesters/figshare.py
@@ -53,9 +53,12 @@ class FigshareHarvester(JSONHarvester):
         """ Figshare should always have a 24 hour delay because they
         manually go through and check for test projects. Most of them
         are removed within 24 hours.
+
+        So, we will shift everything back a day with harvesting to ensure
+        nothing is harvested on the day of.
         """
         start_date = start_date - timedelta(1) if start_date else date.today() - timedelta(2)
-        end_date = end_date - timedelta(1) if end_date else (date.today() - timedelta(1))
+        end_date = end_date - timedelta(1) if end_date else date.today() - timedelta(1)
 
         search_url = '{0}{1}&to_date={2}'.format(
             self.URL,

--- a/scrapi/harvesters/osf.py
+++ b/scrapi/harvesters/osf.py
@@ -96,10 +96,10 @@ class OSFHarvester(JSONHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = start_date or date.today().isoformat()
-        end_date = end_date or (date.today() - timedelta(1)).isoformat()
+        start_date = start_date or date.today()
+        end_date = end_date or date.today() - timedelta(1)
 
-        search_url = self.URL.format(start_date, end_date)
+        search_url = self.URL.format(start_date.isoformat(), end_date.isoformat())
         records = self.get_records(search_url)
 
         record_list = []

--- a/scrapi/harvesters/osf.py
+++ b/scrapi/harvesters/osf.py
@@ -96,6 +96,9 @@ class OSFHarvester(JSONHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
+        start_date = start_date if start_date else date.today().isoformat()
+        end_date = end_date if end_date else (date.today() - timedelta(1)).isoformat()
+
         search_url = self.URL.format(start_date, end_date)
         records = self.get_records(search_url)
 

--- a/scrapi/harvesters/osf.py
+++ b/scrapi/harvesters/osf.py
@@ -96,8 +96,8 @@ class OSFHarvester(JSONHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = start_date or date.today()
-        end_date = end_date or date.today() - timedelta(1)
+        start_date = start_date or date.today() - timedelta(1)
+        end_date = end_date or date.today()
 
         search_url = self.URL.format(start_date.isoformat(), end_date.isoformat())
         records = self.get_records(search_url)

--- a/scrapi/harvesters/osf.py
+++ b/scrapi/harvesters/osf.py
@@ -96,8 +96,8 @@ class OSFHarvester(JSONHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = start_date if start_date else date.today().isoformat()
-        end_date = end_date if end_date else (date.today() - timedelta(1)).isoformat()
+        start_date = start_date or date.today().isoformat()
+        end_date = end_date or (date.today() - timedelta(1)).isoformat()
 
         search_url = self.URL.format(start_date, end_date)
         records = self.get_records(search_url)

--- a/scrapi/harvesters/osf.py
+++ b/scrapi/harvesters/osf.py
@@ -94,9 +94,7 @@ class OSFHarvester(JSONHarvester):
             )
         }
 
-    def harvest(self, days_back=1):
-        start_date = str(date.today() - timedelta(int(days_back)))
-        end_date = str(date.today())
+    def harvest(self, start_date=None, end_date=None):
 
         search_url = self.URL.format(start_date, end_date)
         records = self.get_records(search_url)

--- a/scrapi/harvesters/osf.py
+++ b/scrapi/harvesters/osf.py
@@ -16,6 +16,7 @@ from datetime import date, timedelta
 from nameparser import HumanName
 
 from scrapi import requests
+from scrapi import settings
 from scrapi.base import JSONHarvester
 from scrapi.linter.document import RawDocument
 from scrapi.base.helpers import build_properties
@@ -96,7 +97,7 @@ class OSFHarvester(JSONHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = start_date or date.today() - timedelta(1)
+        start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
         end_date = end_date or date.today()
 
         search_url = self.URL.format(start_date.isoformat(), end_date.isoformat())

--- a/scrapi/harvesters/plos.py
+++ b/scrapi/harvesters/plos.py
@@ -25,6 +25,7 @@ from lxml import etree
 from dateutil.parser import *
 
 from scrapi import requests
+from scrapi import settings
 from scrapi.base import XMLHarvester
 from scrapi.linter.document import RawDocument
 from scrapi.base.helpers import default_name_parser, build_properties, compose, single_result
@@ -76,7 +77,7 @@ class PlosHarvester(XMLHarvester):
 
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = start_date or date.today() - timedelta(1)
+        start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
         end_date = end_date or date.today()
 
         if not PLOS_API_KEY:

--- a/scrapi/harvesters/plos.py
+++ b/scrapi/harvesters/plos.py
@@ -19,6 +19,7 @@ Sample API query: http://api.plos.org/search?q=publication_date:[2015-01-30T00:0
 from __future__ import unicode_literals
 
 import logging
+from datetime import date, timedelta
 
 from lxml import etree
 from dateutil.parser import *
@@ -74,6 +75,10 @@ class PlosHarvester(XMLHarvester):
             current_row += self.MAX_ROWS_PER_REQUEST
 
     def harvest(self, start_date=None, end_date=None):
+
+        start_date = start_date or date.today() - timedelta(1)
+        end_date = end_date or date.today()
+
         if not PLOS_API_KEY:
             return []
 
@@ -85,7 +90,7 @@ class PlosHarvester(XMLHarvester):
                 'docID': row.xpath("str[@name='id']")[0].text.decode('utf-8'),
             })
             for row in
-            self.fetch_rows(start_date, end_date)
+            self.fetch_rows(start_date.isoformat(), end_date.isoformat())
             if row.xpath("arr[@name='abstract']")
             or row.xpath("str[@name='author_display']")
         ]

--- a/scrapi/harvesters/scitech.py
+++ b/scrapi/harvesters/scitech.py
@@ -7,7 +7,7 @@ Example API query: http://www.osti.gov/scitech/scitechxml?EntryDateFrom=02%2F02%
 
 from __future__ import unicode_literals
 
-from datetime import datetime
+from datetime import datetime, date, timedelta
 
 from lxml import etree
 
@@ -62,8 +62,8 @@ class SciTechHarvester(XMLHarvester):
         page = 0
         morepages = True
 
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().strftime('%m/%d/%Y')
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().strftime('%m/%d/%Y')
+        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().strftime('%m/%d/%Y') if start_date else date.today().strftime('%m/%d/%Y')
+        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().strftime('%m/%d/%Y') if end_date else (date.today() - timedelta(1)).strftime('%m/%d/%Y')
 
         while morepages:
             resp = requests.get(self.base_url, params={

--- a/scrapi/harvesters/scitech.py
+++ b/scrapi/harvesters/scitech.py
@@ -58,8 +58,8 @@ class SciTechHarvester(XMLHarvester):
         page = 0
         morepages = True
 
-        start_date = start_date or date.today()
-        end_date = end_date or date.today() - timedelta(1)
+        start_date = start_date or date.today() - timedelta(1)
+        end_date = end_date or date.today()
 
         while morepages:
             resp = requests.get(self.base_url, params={

--- a/scrapi/harvesters/scitech.py
+++ b/scrapi/harvesters/scitech.py
@@ -4,17 +4,13 @@ A harvester for the DoE's SciTech Connect Database. Makes use of SciTech's XML Q
 Example API query: http://www.osti.gov/scitech/scitechxml?EntryDateFrom=02%2F02%2F2015&page=0
 """
 
-
 from __future__ import unicode_literals
 
-from datetime import datetime, date, timedelta
-
 from lxml import etree
-
 from dateutil.parser import *
+from datetime import date, timedelta
 
 from scrapi import requests
-
 from scrapi.base import XMLHarvester
 from scrapi.linter import RawDocument
 from scrapi.base.schemas import DOESCHEMA
@@ -62,14 +58,14 @@ class SciTechHarvester(XMLHarvester):
         page = 0
         morepages = True
 
-        start_date = datetime.strptime(start_date, '%Y-%m-%d').date().strftime('%m/%d/%Y') if start_date else date.today().strftime('%m/%d/%Y')
-        end_date = datetime.strptime(end_date, '%Y-%m-%d').date().strftime('%m/%d/%Y') if end_date else (date.today() - timedelta(1)).strftime('%m/%d/%Y')
+        start_date = start_date or date.today()
+        end_date = end_date or date.today() - timedelta(1)
 
         while morepages:
             resp = requests.get(self.base_url, params={
                 'page': page,
-                'EntryDateTo': end_date,
-                'EntryDateFrom': start_date,
+                'EntryDateTo': end_date.strftime('%m/%d/%Y'),
+                'EntryDateFrom': start_date.strftime('%m/%d/%Y'),
             })
 
             xml = etree.XML(resp.content)

--- a/scrapi/harvesters/scitech.py
+++ b/scrapi/harvesters/scitech.py
@@ -11,9 +11,11 @@ from dateutil.parser import *
 from datetime import date, timedelta
 
 from scrapi import requests
+from scrapi import settings
 from scrapi.base import XMLHarvester
 from scrapi.linter import RawDocument
 from scrapi.base.schemas import DOESCHEMA
+from scrapi.util import format_date_with_slashes
 
 NAME = 'scitech'
 
@@ -58,14 +60,14 @@ class SciTechHarvester(XMLHarvester):
         page = 0
         morepages = True
 
-        start_date = start_date or date.today() - timedelta(1)
+        start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
         end_date = end_date or date.today()
 
         while morepages:
             resp = requests.get(self.base_url, params={
                 'page': page,
-                'EntryDateTo': end_date.strftime('%m/%d/%Y'),
-                'EntryDateFrom': start_date.strftime('%m/%d/%Y'),
+                'EntryDateTo': format_date_with_slashes(start_date),
+                'EntryDateFrom': format_date_with_slashes(end_date),
             })
 
             xml = etree.XML(resp.content)

--- a/scrapi/harvesters/stepic.py
+++ b/scrapi/harvesters/stepic.py
@@ -54,6 +54,8 @@ class StepicHarvester(JSONHarvester):
         }
 
     def harvest(self, start_date=None, end_date=None):
+        # TODO - stepic has no means of querying by date, we should add handling for the
+        # start and end date once it does.
 
         search_url = self.URL
         records = self.get_records(search_url)

--- a/scrapi/harvesters/stepic.py
+++ b/scrapi/harvesters/stepic.py
@@ -53,7 +53,7 @@ class StepicHarvester(JSONHarvester):
             'languages': ('/language', lambda x: [pycountry.languages.get(alpha2=x).terminology])
         }
 
-    def harvest(self, days_back=1):
+    def harvest(self, start_date=None, end_date=None):
 
         search_url = self.URL
         records = self.get_records(search_url)

--- a/scrapi/settings/defaults.py
+++ b/scrapi/settings/defaults.py
@@ -16,6 +16,8 @@ FLUENTD_ARGS = {
     'tag': 'app.scrapi'
 }
 
+DAYS_BACK = 2
+
 SCRAPI_URL = 'http://173.255.232.219'
 
 ES_SEARCH_MAPPING = {

--- a/scrapi/tasks.py
+++ b/scrapi/tasks.py
@@ -25,8 +25,8 @@ logger = logging.getLogger(__name__)
 def run_harvester(harvester_name, start_date=None, end_date=None):
     logger.info('Running harvester "{}"'.format(harvester_name))
 
-    start_date = datetime.strptime(start_date, '%Y-%m-%d').date().isoformat() if start_date else (date.today() - timedelta(1)).isoformat()
-    end_date = datetime.strptime(end_date, '%Y-%m-%d').date().isoformat() if end_date else date.today().isoformat()
+    start_date = start_date or date.today() - timedelta(1)
+    end_date = end_date or date.today()
 
     normalization = begin_normalization.s(harvester_name)
     start_harvest = harvest.si(harvester_name, timestamp(), start_date=start_date, end_date=end_date)
@@ -41,8 +41,8 @@ def harvest(harvester_name, job_created, start_date=None, end_date=None):
     harvest_started = timestamp()
     harvester = registry[harvester_name]
 
-    start_date = datetime.strptime(start_date, '%Y-%m-%d').date().isoformat() if start_date else (date.today() - timedelta(1)).isoformat()
-    end_date = datetime.strptime(end_date, '%Y-%m-%d').date().isoformat() if end_date else date.today().isoformat()
+    start_date = start_date if start_date else date.today() - timedelta(1)
+    end_date = end_date if end_date else date.today()
 
     logger.info('Harvester "{}" has begun harvesting'.format(harvester_name))
 

--- a/scrapi/tasks.py
+++ b/scrapi/tasks.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
 import requests
 from celery import Celery

--- a/scrapi/tasks.py
+++ b/scrapi/tasks.py
@@ -41,8 +41,8 @@ def harvest(harvester_name, job_created, start_date=None, end_date=None):
     harvest_started = timestamp()
     harvester = registry[harvester_name]
 
-    start_date = start_date if start_date else date.today() - timedelta(settings.DAYS_BACK)
-    end_date = end_date if end_date else date.today()
+    start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
+    end_date = end_date or date.today()
 
     logger.info('Harvester "{}" has begun harvesting'.format(harvester_name))
 

--- a/scrapi/tasks.py
+++ b/scrapi/tasks.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 def run_harvester(harvester_name, start_date=None, end_date=None):
     logger.info('Running harvester "{}"'.format(harvester_name))
 
-    start_date = start_date or date.today() - timedelta(1)
+    start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
     end_date = end_date or date.today()
 
     normalization = begin_normalization.s(harvester_name)
@@ -41,7 +41,7 @@ def harvest(harvester_name, job_created, start_date=None, end_date=None):
     harvest_started = timestamp()
     harvester = registry[harvester_name]
 
-    start_date = start_date if start_date else date.today() - timedelta(1)
+    start_date = start_date if start_date else date.today() - timedelta(settings.DAYS_BACK)
     end_date = end_date if end_date else date.today()
 
     logger.info('Harvester "{}" has begun harvesting'.format(harvester_name))

--- a/scrapi/util.py
+++ b/scrapi/util.py
@@ -33,3 +33,7 @@ def stamp_from_raw(raw_doc, **kwargs):
     stamps = raw_doc['timestamps']
     stamps.update(kwargs)
     return stamps
+
+
+def format_date_with_slashes(date):
+    return date.strftime('%m/%d/%Y')

--- a/tasks.py
+++ b/tasks.py
@@ -121,8 +121,8 @@ def harvesters(async=False, start=None, end=None):
     settings.CELERY_ALWAYS_EAGER = not async
     from scrapi.tasks import run_harvester
 
-    start = datetime.strptime(start, '%Y-%m-%d').date() if start else (date.today() - timedelta(settings.DAYS_BACK))
-    end = datetime.strptime(end, '%Y-%m-%d').date() if end else date.today()
+    start = parser.parse(start) if start else date.today() - timedelta(settings.DAYS_BACK)
+    end = parser.parse(end) if end else date.today()
 
     exceptions = []
     for harvester_name in registry.keys():
@@ -141,8 +141,8 @@ def harvesters(async=False, start=None, end=None):
 def check_archive(harvester=None, reprocess=False, async=False, start=None, end=None):
     settings.CELERY_ALWAYS_EAGER = not async
 
-    start = datetime.strptime(start, '%Y-%m-%d').date() if start else date.today() - timedelta(1)
-    end = datetime.strptime(end, '%Y-%m-%d').date() if end else date.today()
+    start = parser.parse(start) if start else date.today() - timedelta(settings.DAYS_BACK)
+    end = parser.parse(end) if end else date.today()
 
     if harvester:
         from scrapi.tasks import check_archive as check

--- a/tasks.py
+++ b/tasks.py
@@ -7,6 +7,7 @@ from invoke import run, task
 from elasticsearch import helpers
 
 import scrapi.harvesters  # noqa
+from dateutil import parser
 from scrapi import linter
 from scrapi import registry
 from scrapi import settings
@@ -109,7 +110,8 @@ def harvester(harvester_name, async=False, start=None, end=None):
     if not registry.get(harvester_name):
         raise ValueError('No such harvesters {}'.format(harvester_name))
 
-    start = datetime.strptime(start, '%Y-%m-%d').date() if start else (date.today() - timedelta(settings.DAYS_BACK))
+    start = parser.parse(start) if start else date.today() - timedelta(settings.DAYS_BACK)
+    end = parser.parse(end) if end else date.today()
 
     run_harvester.delay(harvester_name, start_date=start, end_date=end)
 

--- a/tasks.py
+++ b/tasks.py
@@ -109,8 +109,7 @@ def harvester(harvester_name, async=False, start=None, end=None):
     if not registry.get(harvester_name):
         raise ValueError('No such harvesters {}'.format(harvester_name))
 
-    start = datetime.strptime(start, '%Y-%m-%d').date().isoformat() if start else (date.today() - timedelta(1)).isoformat()
-    end = datetime.strptime(end, '%Y-%m-%d').date().isoformat() if end else date.today().isoformat()
+    start = datetime.strptime(start, '%Y-%m-%d').date() if start else (date.today() - timedelta(1))
 
     run_harvester.delay(harvester_name, start_date=start, end_date=end)
 
@@ -120,13 +119,13 @@ def harvesters(async=False, start=None, end=None):
     settings.CELERY_ALWAYS_EAGER = not async
     from scrapi.tasks import run_harvester
 
-    start = datetime.strptime(start, '%Y-%m-%d').date().isoformat() if start else (date.today() - timedelta(1)).isoformat()
-    end = datetime.strptime(end, '%Y-%m-%d').date().isoformat() if end else date.today().isoformat()
+    start = datetime.strptime(start, '%Y-%m-%d').date() if start else (date.today() - timedelta(1))
+    end = datetime.strptime(end, '%Y-%m-%d').date() if end else date.today()
 
     exceptions = []
     for harvester_name in registry.keys():
         try:
-            run_harvester.delay(harvester_name, start_date=start.isoformat(), end_date=end.isoformat())
+            run_harvester.delay(harvester_name, start_date=start, end_date=end)
         except Exception as e:
             logger.exception(e)
             exceptions.append(e)
@@ -140,8 +139,8 @@ def harvesters(async=False, start=None, end=None):
 def check_archive(harvester=None, reprocess=False, async=False, start=None, end=None):
     settings.CELERY_ALWAYS_EAGER = not async
 
-    start = datetime.strptime(start, '%Y-%m-%d').date().isoformat() if start else (date.today() - timedelta(1)).isoformat()
-    end = datetime.strptime(end, '%Y-%m-%d').date().isoformat() if end else date.today().isoformat()
+    start = datetime.strptime(start, '%Y-%m-%d').date() if start else date.today() - timedelta(1)
+    end = datetime.strptime(end, '%Y-%m-%d').date() if end else date.today()
 
     if harvester:
         from scrapi.tasks import check_archive as check

--- a/tasks.py
+++ b/tasks.py
@@ -110,8 +110,8 @@ def harvester(harvester_name, async=False, start=None, end=None):
     if not registry.get(harvester_name):
         raise ValueError('No such harvesters {}'.format(harvester_name))
 
-    start = parse(start) if start else date.today() - timedelta(settings.DAYS_BACK)
-    end = parse(end) if end else date.today()
+    start = parse(start) or date.today() - timedelta(settings.DAYS_BACK)
+    end = parse(end) or date.today()
 
     run_harvester.delay(harvester_name, start_date=start, end_date=end)
 
@@ -121,8 +121,8 @@ def harvesters(async=False, start=None, end=None):
     settings.CELERY_ALWAYS_EAGER = not async
     from scrapi.tasks import run_harvester
 
-    start = parse(start) if start else date.today() - timedelta(settings.DAYS_BACK)
-    end = parse(end) if end else date.today()
+    start = parse(start) or date.today() - timedelta(settings.DAYS_BACK)
+    end = parse(end) or date.today()
 
     exceptions = []
     for harvester_name in registry.keys():
@@ -141,8 +141,8 @@ def harvesters(async=False, start=None, end=None):
 def check_archive(harvester=None, reprocess=False, async=False, start=None, end=None):
     settings.CELERY_ALWAYS_EAGER = not async
 
-    start = parse(start) if start else date.today() - timedelta(settings.DAYS_BACK)
-    end = parse(end) if end else date.today()
+    start = parse(start) or date.today() - timedelta(settings.DAYS_BACK)
+    end = parse(end) or date.today()
 
     if harvester:
         from scrapi.tasks import check_archive as check

--- a/tasks.py
+++ b/tasks.py
@@ -1,6 +1,6 @@
 import logging
 import platform
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta
 
 import urllib
 from invoke import run, task

--- a/tasks.py
+++ b/tasks.py
@@ -7,7 +7,7 @@ from invoke import run, task
 from elasticsearch import helpers
 
 import scrapi.harvesters  # noqa
-from dateutil import parser
+from dateutil.parser import parse
 from scrapi import linter
 from scrapi import registry
 from scrapi import settings
@@ -110,8 +110,8 @@ def harvester(harvester_name, async=False, start=None, end=None):
     if not registry.get(harvester_name):
         raise ValueError('No such harvesters {}'.format(harvester_name))
 
-    start = parser.parse(start) if start else date.today() - timedelta(settings.DAYS_BACK)
-    end = parser.parse(end) if end else date.today()
+    start = parse(start) if start else date.today() - timedelta(settings.DAYS_BACK)
+    end = parse(end) if end else date.today()
 
     run_harvester.delay(harvester_name, start_date=start, end_date=end)
 
@@ -121,8 +121,8 @@ def harvesters(async=False, start=None, end=None):
     settings.CELERY_ALWAYS_EAGER = not async
     from scrapi.tasks import run_harvester
 
-    start = parser.parse(start) if start else date.today() - timedelta(settings.DAYS_BACK)
-    end = parser.parse(end) if end else date.today()
+    start = parse(start) if start else date.today() - timedelta(settings.DAYS_BACK)
+    end = parse(end) if end else date.today()
 
     exceptions = []
     for harvester_name in registry.keys():
@@ -141,8 +141,8 @@ def harvesters(async=False, start=None, end=None):
 def check_archive(harvester=None, reprocess=False, async=False, start=None, end=None):
     settings.CELERY_ALWAYS_EAGER = not async
 
-    start = parser.parse(start) if start else date.today() - timedelta(settings.DAYS_BACK)
-    end = parser.parse(end) if end else date.today()
+    start = parse(start) if start else date.today() - timedelta(settings.DAYS_BACK)
+    end = parse(end) if end else date.today()
 
     if harvester:
         from scrapi.tasks import check_archive as check

--- a/tasks.py
+++ b/tasks.py
@@ -109,7 +109,7 @@ def harvester(harvester_name, async=False, start=None, end=None):
     if not registry.get(harvester_name):
         raise ValueError('No such harvesters {}'.format(harvester_name))
 
-    start = datetime.strptime(start, '%Y-%m-%d').date() if start else (date.today() - timedelta(1))
+    start = datetime.strptime(start, '%Y-%m-%d').date() if start else (date.today() - timedelta(settings.DAYS_BACK))
 
     run_harvester.delay(harvester_name, start_date=start, end_date=end)
 
@@ -119,7 +119,7 @@ def harvesters(async=False, start=None, end=None):
     settings.CELERY_ALWAYS_EAGER = not async
     from scrapi.tasks import run_harvester
 
-    start = datetime.strptime(start, '%Y-%m-%d').date() if start else (date.today() - timedelta(1))
+    start = datetime.strptime(start, '%Y-%m-%d').date() if start else (date.today() - timedelta(settings.DAYS_BACK))
     end = datetime.strptime(end, '%Y-%m-%d').date() if end else date.today()
 
     exceptions = []

--- a/tests/test_harvesters.py
+++ b/tests/test_harvesters.py
@@ -2,12 +2,12 @@ import logging
 
 import vcr
 import pytest
-from mock import patch
 from freezegun import freeze_time
 
 from scrapi import registry, requests
 
 logger = logging.getLogger(__name__)
+
 
 @freeze_time("2007-12-21")
 @pytest.mark.parametrize('harvester_name', sorted(map(str, registry.keys())))

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,6 +2,8 @@ import mock
 import pytest
 
 from scrapi import events
+# from scrapi import tasks
+from tests import utils
 
 
 @pytest.fixture(autouse=True)
@@ -90,18 +92,20 @@ def test_logged_decorator_skipped(mock_dispatch):
     ])
 
 
-def test_logged_decorator_stargs(mock_dispatch):
-    @events.logged('testing')
-    def logged_func(test, *args):
-        return 'share'
+## TODO - logging does not currently support args
+# def test_logged_decorator_stargs(mock_dispatch):
+#     @events.logged('testing')
+#     def logged_func(test, *args):
+#         return 'share'
 
-    assert logged_func('baz', 1, 2, 3) == 'share'
-    mock_dispatch.assert_has_calls([
-        mock.call('testing', events.STARTED, _index=None, test='baz', args=[1, 2, 3]),
-        mock.call('testing', events.COMPLETED, _index=None, test='baz', args=[1, 2, 3])
-    ])
+#     assert logged_func('baz', 1, 2, 3) == 'share'
+#     mock_dispatch.assert_has_calls([
+#         mock.call('testing', events.STARTED, _index=None, test='baz', args=[1, 2, 3]),
+#         mock.call('testing', events.COMPLETED, _index=None, test='baz', args=[1, 2, 3])
+#     ])
 
 
+## TODO - Logging currently breaks apart kwargs in a dictionary, maybe should change
 def test_logged_decorator_kwargs(mock_dispatch):
     @events.logged('testing')
     def logged_func(test, pika='chu', **kwargs):
@@ -109,6 +113,6 @@ def test_logged_decorator_kwargs(mock_dispatch):
 
     assert logged_func('baz', tota='dile') == 'share'
     mock_dispatch.assert_has_calls([
-        mock.call('testing', events.STARTED, _index=None, test='baz', pika='chu', kwargs={'tota': 'dile'}),
-        mock.call('testing', events.COMPLETED, _index=None, test='baz', pika='chu', kwargs={'tota': 'dile'}),
+        mock.call('testing', events.STARTED, _index=None, test='baz', pika='chu', tota='dile'),
+        mock.call('testing', events.COMPLETED, _index=None, test='baz', pika='chu', tota='dile'),
     ])

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -92,20 +92,18 @@ def test_logged_decorator_skipped(mock_dispatch):
     ])
 
 
-## TODO - logging does not currently support args
-# def test_logged_decorator_stargs(mock_dispatch):
-#     @events.logged('testing')
-#     def logged_func(test, *args):
-#         return 'share'
+def test_logged_decorator_stargs(mock_dispatch):
+    @events.logged('testing')
+    def logged_func(test, *args):
+        return 'share'
 
-#     assert logged_func('baz', 1, 2, 3) == 'share'
-#     mock_dispatch.assert_has_calls([
-#         mock.call('testing', events.STARTED, _index=None, test='baz', args=[1, 2, 3]),
-#         mock.call('testing', events.COMPLETED, _index=None, test='baz', args=[1, 2, 3])
-#     ])
+    assert logged_func('baz', 1, 2, 3) == 'share'
+    mock_dispatch.assert_has_calls([
+        mock.call('testing', events.STARTED, _index=None, test='baz', args=[1, 2, 3]),
+        mock.call('testing', events.COMPLETED, _index=None, test='baz', args=[1, 2, 3])
+    ])
 
 
-## TODO - Logging currently breaks apart kwargs in a dictionary, maybe should change
 def test_logged_decorator_kwargs(mock_dispatch):
     @events.logged('testing')
     def logged_func(test, pika='chu', **kwargs):
@@ -113,6 +111,6 @@ def test_logged_decorator_kwargs(mock_dispatch):
 
     assert logged_func('baz', tota='dile') == 'share'
     mock_dispatch.assert_has_calls([
-        mock.call('testing', events.STARTED, _index=None, test='baz', pika='chu', tota='dile'),
-        mock.call('testing', events.COMPLETED, _index=None, test='baz', pika='chu', tota='dile'),
+        mock.call('testing', events.STARTED, _index=None, test='baz', pika='chu', kwargs={'tota': 'dile'}),
+        mock.call('testing', events.COMPLETED, _index=None, test='baz', pika='chu', kwargs={'tota': 'dile'}),
     ])

--- a/tests/test_oai_harvester.py
+++ b/tests/test_oai_harvester.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import httpretty
+from datetime import datetime
 
 from scrapi.base import OAIHarvester
 from scrapi.linter import RawDocument
@@ -16,7 +17,10 @@ class TestHarvester(OAIHarvester):
     property_list = ['type', 'source', 'publisher', 'format', 'date']
 
     @httpretty.activate
-    def harvest(self, start_date='2015-03-14', end_date='2015-03-16'):
+    def harvest(self, start_date=None, end_date=None):
+
+        start_date = datetime(2015, 03, 14).date()
+        end_date = datetime(2015, 03, 16).date()
 
         request_url = 'http://validAI.edu/?from={}&to={}'.format(start_date, end_date)
 

--- a/tests/test_oai_harvester.py
+++ b/tests/test_oai_harvester.py
@@ -16,10 +16,7 @@ class TestHarvester(OAIHarvester):
     property_list = ['type', 'source', 'publisher', 'format', 'date']
 
     @httpretty.activate
-    def harvest(self, days_back=1):
-
-        start_date = '2015-03-14'
-        end_date = '2015-03-16'
+    def harvest(self, start_date='2015-03-14', end_date='2015-03-16'):
 
         request_url = 'http://validAI.edu/?from={}&to={}'.format(start_date, end_date)
 

--- a/tests/test_oai_harvester.py
+++ b/tests/test_oai_harvester.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 import httpretty
-from datetime import datetime
+from datetime import date
 
 from scrapi.base import OAIHarvester
 from scrapi.linter import RawDocument
@@ -19,8 +19,8 @@ class TestHarvester(OAIHarvester):
     @httpretty.activate
     def harvest(self, start_date=None, end_date=None):
 
-        start_date = datetime(2015, 03, 14).date()
-        end_date = datetime(2015, 03, 16).date()
+        start_date = date(2015, 03, 14)
+        end_date = date(2015, 03, 16)
 
         request_url = 'http://validAI.edu/?from={}&to={}'.format(start_date, end_date)
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,7 +1,6 @@
 import mock
 import pytest
 
-from scrapi import events
 from scrapi import settings
 
 settings.DEBUG = False
@@ -18,6 +17,7 @@ def get_processor(monkeypatch):
     mock_get_proc = mock.MagicMock()
     monkeypatch.setattr('scrapi.processing.get_processor', mock_get_proc)
     return mock_get_proc
+
 
 def raise_exception(x):
     if x == 'storage':
@@ -51,7 +51,6 @@ def test_raw_calls_all_throwing(get_processor):
 
     with pytest.raises(Exception):
         processing.process_raw(mock.MagicMock(), {})
-
 
 
 def test_raises_on_bad_processor():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,6 @@
 import mock
 import pytest
-from datetime import datetime, timedelta
+from datetime import date, timedelta
 from freezegun import freeze_time
 
 from scrapi import tasks
@@ -47,7 +47,7 @@ def test_run_harvester_calls(monkeypatch):
 
     assert mock_harvest.si.called
     assert mock_begin_norm.s.called
-    end_date = datetime(2015, 03, 16).date()
+    end_date = date(2015, 03, 16)
     start_date = end_date - timedelta(settings.DAYS_BACK)
 
     mock_begin_norm.s.assert_called_once_with('test')
@@ -61,8 +61,8 @@ def test_run_harvester_daysback(monkeypatch):
     monkeypatch.setattr('scrapi.tasks.harvest', mock_harvest)
     monkeypatch.setattr('scrapi.tasks.begin_normalization', mock_begin_norm)
 
-    start_date = datetime(2015, 03, 14).date()
-    end_date = datetime(2015, 03, 16).date()
+    start_date = date(2015, 03, 14)
+    end_date = date(2015, 03, 16)
 
     tasks.run_harvester('test', start_date=start_date, end_date=end_date)
 
@@ -82,8 +82,8 @@ def test_harvest_runs_harvest(harvester):
 
 @pytest.mark.usefixtures('harvester')
 def test_harvest_days_back(harvester):
-    start_date = datetime(2015, 03, 14).date()
-    end_date = datetime(2015, 03, 16).date()
+    start_date = date(2015, 03, 14)
+    end_date = date(2015, 03, 16)
 
     _, timestamps = tasks.harvest('test', 'TIME', start_date=start_date, end_date=end_date)
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -47,9 +47,8 @@ def test_run_harvester_calls(monkeypatch):
 
     assert mock_harvest.si.called
     assert mock_begin_norm.s.called
-    # import ipdb; ipdb.set_trace()
-    start_date = datetime.strptime('2015-03-15', '%Y-%m-%d').date()
-    end_date = datetime.strptime('2015-03-16', '%Y-%m-%d').date()
+    start_date = datetime(2015, 03, 15).date()
+    end_date = datetime(2015, 03, 16).date()
 
     mock_begin_norm.s.assert_called_once_with('test')
     mock_harvest.si.assert_called_once_with('test', 'TIME', start_date=start_date, end_date=end_date)
@@ -62,13 +61,16 @@ def test_run_harvester_daysback(monkeypatch):
     monkeypatch.setattr('scrapi.tasks.harvest', mock_harvest)
     monkeypatch.setattr('scrapi.tasks.begin_normalization', mock_begin_norm)
 
-    tasks.run_harvester('test', start_date='2015-03-06', end_date='2015-03-16')
+    start_date = datetime(2015, 03, 14).date()
+    end_date = datetime(2015, 03, 16).date()
+
+    tasks.run_harvester('test', start_date=start_date, end_date=end_date)
 
     assert mock_harvest.si.called
     assert mock_begin_norm.s.called
 
     mock_begin_norm.s.assert_called_once_with('test')
-    mock_harvest.si.assert_called_once_with('test', 'TIME', start_date='2015-03-06', end_date='2015-03-16')
+    mock_harvest.si.assert_called_once_with('test', 'TIME', start_date=start_date, end_date=end_date)
 
 
 @pytest.mark.usefixtures('harvester')
@@ -80,7 +82,10 @@ def test_harvest_runs_harvest(harvester):
 
 @pytest.mark.usefixtures('harvester')
 def test_harvest_days_back(harvester):
-    _, timestamps = tasks.harvest('test', 'TIME', start_date='2015-03-06', end_date='2015-03-16')
+    start_date = datetime(2015, 03, 14).date()
+    end_date = datetime(2015, 03, 16).date()
+
+    _, timestamps = tasks.harvest('test', 'TIME', start_date=start_date, end_date=end_date)
 
     keys = ['harvestFinished', 'harvestTaskCreated', 'harvestStarted']
 
@@ -88,7 +93,7 @@ def test_harvest_days_back(harvester):
         assert key in timestamps.keys()
 
     assert harvester.harvest.called
-    harvester.harvest.assert_called_once_with(start_date='2015-03-06', end_date='2015-03-16')
+    harvester.harvest.assert_called_once_with(start_date=start_date, end_date=end_date)
 
 
 @pytest.mark.usefixtures('harvester')

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+from datetime import datetime
 from freezegun import freeze_time
 
 from scrapi import tasks
@@ -46,9 +47,12 @@ def test_run_harvester_calls(monkeypatch):
 
     assert mock_harvest.si.called
     assert mock_begin_norm.s.called
+    # import ipdb; ipdb.set_trace()
+    start_date = datetime.strptime('2015-03-15', '%Y-%m-%d').date()
+    end_date = datetime.strptime('2015-03-16', '%Y-%m-%d').date()
 
     mock_begin_norm.s.assert_called_once_with('test')
-    mock_harvest.si.assert_called_once_with('test', 'TIME', start_date='2015-03-15', end_date='2015-03-16')
+    mock_harvest.si.assert_called_once_with('test', 'TIME', start_date=start_date, end_date=end_date)
 
 
 def test_run_harvester_daysback(monkeypatch):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,6 +1,6 @@
 import mock
 import pytest
-from datetime import datetime
+from datetime import datetime, timedelta
 from freezegun import freeze_time
 
 from scrapi import tasks
@@ -47,8 +47,8 @@ def test_run_harvester_calls(monkeypatch):
 
     assert mock_harvest.si.called
     assert mock_begin_norm.s.called
-    start_date = datetime(2015, 03, 15).date()
     end_date = datetime(2015, 03, 16).date()
+    start_date = end_date - timedelta(settings.DAYS_BACK)
 
     mock_begin_norm.s.assert_called_once_with('test')
     mock_harvest.si.assert_called_once_with('test', 'TIME', start_date=start_date, end_date=end_date)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+from freezegun import freeze_time
 
 from scrapi import tasks
 from scrapi import settings
@@ -33,6 +34,7 @@ def raw_docs():
     ]
 
 
+@freeze_time("2015-03-16")
 def test_run_harvester_calls(monkeypatch):
     mock_harvest = mock.MagicMock()
     mock_begin_norm = mock.MagicMock()
@@ -46,7 +48,7 @@ def test_run_harvester_calls(monkeypatch):
     assert mock_begin_norm.s.called
 
     mock_begin_norm.s.assert_called_once_with('test')
-    mock_harvest.si.assert_called_once_with('test', 'TIME', days_back=1)
+    mock_harvest.si.assert_called_once_with('test', 'TIME', start_date='2015-03-15', end_date='2015-03-16')
 
 
 def test_run_harvester_daysback(monkeypatch):
@@ -56,13 +58,13 @@ def test_run_harvester_daysback(monkeypatch):
     monkeypatch.setattr('scrapi.tasks.harvest', mock_harvest)
     monkeypatch.setattr('scrapi.tasks.begin_normalization', mock_begin_norm)
 
-    tasks.run_harvester('test', days_back=10)
+    tasks.run_harvester('test', start_date='2015-03-06', end_date='2015-03-16')
 
     assert mock_harvest.si.called
     assert mock_begin_norm.s.called
 
     mock_begin_norm.s.assert_called_once_with('test')
-    mock_harvest.si.assert_called_once_with('test', 'TIME', days_back=10)
+    mock_harvest.si.assert_called_once_with('test', 'TIME', start_date='2015-03-06', end_date='2015-03-16')
 
 
 @pytest.mark.usefixtures('harvester')
@@ -74,7 +76,7 @@ def test_harvest_runs_harvest(harvester):
 
 @pytest.mark.usefixtures('harvester')
 def test_harvest_days_back(harvester):
-    _, timestamps = tasks.harvest('test', 'TIME', days_back=10)
+    _, timestamps = tasks.harvest('test', 'TIME', start_date='2015-03-06', end_date='2015-03-16')
 
     keys = ['harvestFinished', 'harvestTaskCreated', 'harvestStarted']
 
@@ -82,7 +84,7 @@ def test_harvest_days_back(harvester):
         assert key in timestamps.keys()
 
     assert harvester.harvest.called
-    harvester.harvest.assert_called_once_with(days_back=10)
+    harvester.harvest.assert_called_once_with(start_date='2015-03-06', end_date='2015-03-16')
 
 
 @pytest.mark.usefixtures('harvester')


### PR DESCRIPTION
Remove the "days_back" argument from harvesters and instead use a date range. Defaults to harvesting from the day before to the current day.

- [x] arxiv
- [x] asu
- [x] bhl
- [x] biomedcentral
- [x] calhoun
- [x] calpoly
- [x] caltech
- [x] clinicaltrials
- [x] cmu
- [x] cogprints
- [x] columbia
- [x] crossref
- [x] cuscholar
- [x] dataone
- [x] doepages
- [x] figshare
- [x] mit
- [x] opensiuc
- [x] osf
- [x] plos
- [x] pubmedcentral
- [x] scholarsbank
- [x] scitech
- [x] shareok
- [x] spdataverse
- [x] stcloud
- [x] stepic
- [x] tdar
- [x] texasstate
- [x] trinity
- [x] ucescholarship
- [x] uiucideals
- [x] upennsylvania
- [x] utaustin
- [x] uwashington
- [x] valposcholar
- [x] vtech
- [x] waynestate
- [x] zenodo
