### PR TITLE
Add approved Sets to SHAREOK, remove date from otherProperties for now

### DIFF
--- a/scrapi/harvesters/shareok.py
+++ b/scrapi/harvesters/shareok.py
@@ -17,7 +17,9 @@ class ShareOKHarvester(OAIHarvester):
     timezone_granularity = True
 
     base_url = 'https://shareok.org/oai/request'
+
+    # TODO - add date back in once we fix elasticsearch mapping
     property_list = [
         'type', 'source', 'format',
-        'date', 'description', 'setSpec'
+        'description', 'setSpec'
     ]

--- a/scrapi/harvesters/shareok.py
+++ b/scrapi/harvesters/shareok.py
@@ -23,3 +23,17 @@ class ShareOKHarvester(OAIHarvester):
         'type', 'source', 'format',
         'description', 'setSpec'
     ]
+    approved_sets = [
+        'com_11244_14447',
+        'com_11244_1',
+        'col_11244_14248',
+        'com_11244_6231',
+        'col_11244_7929',
+        'col_11244_7920',
+        'col_11244_10476',
+        'com_11244_10465',
+        'com_11244_10460',
+        'col_11244_10466',
+        'col_11244_10464',
+        'col_11244_10462'
+    ]


### PR DESCRIPTION
Add a list of approves sets to harvest, that do not include undergrad research. 

ES mapping was failing for occasionally malformed dates in otherProperties - will add back in once we fix this. 