### PR TITLE
Add basic postgres backend

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,14 +1,13 @@
+-r requirements.txt
+
 mock==1.0.1
 pytest==2.6.3
 httpretty==0.8.4
 pytest-cov==1.8.1
 ipdb==0.8
 ipython==3.1.0
-
 pep8>=1.5.7,<1.6.0
 pyflakes>=0.8,<0.9
 mccabe>=0.3,<0.4
 flake8==2.3.0
 freezegun==0.3.2
-
--r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ furl==0.4.4
 jsonschema==2.4.0
 jsonpointer==1.7
 pycountry==1.10
+SQLAlchemy==1.0.6

--- a/scrapi/processing/__init__.py
+++ b/scrapi/processing/__init__.py
@@ -3,6 +3,9 @@ import os
 from scrapi import settings
 from scrapi.processing.base import BaseProcessor
 
+# TODO, make generic
+from scrapi.processing.postgres import HarvesterResponse  # noqa
+
 __all__ = []
 for mod in os.listdir(os.path.dirname(__file__)):
     root, ext = os.path.splitext(mod)

--- a/scrapi/processing/base.py
+++ b/scrapi/processing/base.py
@@ -33,3 +33,11 @@ class HarvesterResponseModel(object):
     @abc.abstractmethod
     def get(self, url=None, method=None):
         raise NotImplementedError
+
+    @abc.abstractmethod
+    def save(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def update(self, **kwargs):
+        raise NotImplementedError

--- a/scrapi/processing/base.py
+++ b/scrapi/processing/base.py
@@ -1,3 +1,8 @@
+import abc
+import json
+from requests.structures import CaseInsensitiveDict
+
+
 class BaseProcessor(object):
     NAME = None
 
@@ -6,3 +11,25 @@ class BaseProcessor(object):
 
     def process_normalized(self, raw_doc, normalized, **kwargs):
         pass  # pragma: no cover
+
+
+class HarvesterResponseModel(object):
+
+    class DoesNotExist(Exception):
+        pass  # pragma: no cover
+
+    def json(self):
+        return json.loads(self.content)
+
+    @property
+    def headers(self):
+        return CaseInsensitiveDict(json.loads(self.headers_str))
+
+    @property
+    def text(self):
+        return self.content.decode('utf-8')
+
+    @classmethod
+    @abc.abstractmethod
+    def get(self, url=None, method=None):
+        raise NotImplementedError

--- a/scrapi/processing/cassandra.py
+++ b/scrapi/processing/cassandra.py
@@ -200,16 +200,12 @@ class VersionModel(models.Model):
 
 
 @database.register_model
-class HarvesterResponse(HarvesterResponseModel, models.Model):
+class HarvesterResponse(models.Model, HarvesterResponseModel):
     """A parody of requests.response but stored in cassandra
     Should reflect all methods of a response object
     Contains an additional field time_made, self-explanitory
     """
     __table_name__ = 'responses'
-
-    def __init__(self, *args, **kwargs):
-        super(HarvesterResponse, self).__init__(*args, **kwargs)
-        self.save()
 
     @classmethod
     def get(self, url=None, method=None):

--- a/scrapi/processing/postgres.py
+++ b/scrapi/processing/postgres.py
@@ -233,10 +233,10 @@ class HarvesterResponse(HarvesterResponseModel, Base):
     """
     __tablename__ = 'responses'
 
-    def __init__(self, *args, **kwargs):
-        super(HarvesterResponse, self).__init__(*args, **kwargs)
+    def save(self):
         session.add(self)
         session.commit()
+        return self
 
     method = Column(String, primary_key=True)
     url = Column(String, primary_key=True)
@@ -258,3 +258,17 @@ class HarvesterResponse(HarvesterResponseModel, Base):
         if not ret:
             raise self.DoesNotExist
         return ret
+
+    def update(self, url=None, method=None, ok=None, content=None,
+               encoding=None, headers_str=None, status_code=None, time_made=None):
+
+        self.method = method or self.method
+        self.url = url or self.url
+        self.ok = ok or self.ok
+        self.content = content or self.content
+        self.encoding = encoding or self.encoding
+        self.headers_str = headers_str or self.headers_str
+        self.status_code = status_code or self.status_code
+        self.time_made = time_made or self.time_made
+
+        return self

--- a/scrapi/processing/postgres.py
+++ b/scrapi/processing/postgres.py
@@ -1,0 +1,225 @@
+from __future__ import absolute_import
+
+import logging
+
+from sqlalchemy import create_engine, ForeignKeyConstraint
+from sqlalchemy.ext.declarative import declarative_base
+
+from sqlalchemy.orm import relationship, sessionmaker
+from sqlalchemy import Column, String, Integer, LargeBinary, DateTime, ForeignKey, Table
+
+from sqlalchemy.dialects.postgresql import JSON, ARRAY
+
+from scrapi import events
+from scrapi.processing.base import BaseProcessor
+
+logger = logging.getLogger(__name__)
+
+engine = create_engine('postgresql://localhost/scrapi', echo=True)
+session = sessionmaker(bind=engine)()
+Base = declarative_base(bind=engine)
+
+
+class PostgresProcessor(BaseProcessor):
+    NAME = 'postgres'
+
+    def __init__(self, *args, **kwargs):
+        Base.metadata.create_all()
+        session.commit()
+        super(PostgresProcessor, self).__init__(*args, **kwargs)
+
+    @events.logged(events.PROCESSING, 'raw.postgres')
+    def process_raw(self, raw_doc):
+        source, docID = raw_doc['source'], raw_doc['docID']
+        document = self._get_by_source_id(Document, source, docID) or Document(source=source, docID=docID)
+
+        raw = Raw(
+            source=source,
+            docID=docID,
+            doc=raw_doc['doc'],
+            filetype=raw_doc['filetype']
+        )
+
+        log = Log(**raw_doc['timestamps'])
+
+        document.logs.append(log)
+        document.raws.append(raw)
+
+        session.add(document)
+        session.add(raw)
+        session.add(log)
+        session.commit()
+
+    @events.logged(events.PROCESSING, 'normalized.postgres')
+    def process_normalized(self, raw_doc, normalized):
+        source, docID = raw_doc['source'], raw_doc['docID']
+        document = self._get_by_source_id(Document, source, docID) or Document(source=source, docID=docID)
+
+        norm = Normalized()
+
+        norm.source = source,
+        norm.docID = docID,
+        norm.title = normalized['title'],
+        norm.providerUpdatedDateTime = normalized['providerUpdatedDateTime'],
+        norm.uris = normalized['uris'],
+        norm.description = normalized.get('description'),
+        norm.tags = normalized.get('tags'),
+        norm.subjects = normalized.get('subjects'),
+        norm.languages = normalized.get('languages'),
+        norm.freeToRead = normalized.get('freeToRead'),
+        norm.licenses = normalized.get('licenses'),
+        norm.publisher = normalized.get('publisher'),
+        norm.sponsorships = normalized.get('sponsorships'),
+        norm.version = normalized.get('version'),
+        norm.otherProperties = normalized.get('otherProperties'),
+        norm.shareProperties = normalized.get('shareProperties')
+
+        log = Log(**raw_doc['timestamps'])
+
+        document.normalized.append(norm)
+        document.logs.append(log)
+
+        # TODO: Too much duplication
+        contributors = map(lambda c: Contributor(**c), normalized['contributors'])
+        norm.contributors = contributors
+
+        map(session.add, contributors)
+        session.add(document)
+        session.add(norm)
+        session.add(log)
+        session.commit()
+
+    def _get_by_source_id(self, model, source, docID):
+        return session.query(model).filter_by(source=source, docID=docID).first()
+
+
+class Document(Base):
+    __tablename__ = 'documents'
+
+    source = Column(String, primary_key=True)
+    docID = Column(String, primary_key=True)
+
+    raws = relationship('Raw', backref='document')
+    normalized = relationship('Normalized', backref='document')
+
+    logs = relationship('Log', backref='document')
+
+
+class Raw(Base):
+    __tablename__ = 'raws'
+
+    id = Column(Integer, primary_key=True)
+
+    source = Column(String)
+    docID = Column(String)
+
+    doc = Column(LargeBinary)
+    filetype = Column(String)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            [source, docID],
+            [Document.source, Document.docID]
+        ), {}
+    )
+
+
+contributor_association_table = Table(
+    'contributor_association', Base.metadata,
+    Column('normalized_id', Integer, ForeignKey('normalized.id'), primary_key=True),
+    Column('contributor_id', Integer, ForeignKey('contributors.id'), primary_key=True),
+)
+
+
+class Normalized(Base):
+    __tablename__ = 'normalized'
+
+    id = Column(Integer, primary_key=True)
+
+    source = Column(String)
+    docID = Column(String)
+
+    # This is the schema provided by SHARE
+    contributors = relationship(
+        'Contributor',
+        secondary=contributor_association_table,
+        backref='normalized'
+    )
+
+    title = Column(String)
+    providerUpdatedDateTime = Column(DateTime)
+    description = Column(String)
+    uris = Column(JSON)
+    tags = Column(ARRAY(String))
+    subjects = Column(ARRAY(String))
+    languages = Column(ARRAY(String))
+    freeToRead = Column(JSON)
+    licenses = Column(JSON)
+    publisher = Column(JSON)
+    sponsorships = Column(JSON)
+    version = Column(JSON)
+    otherProperties = Column(JSON)
+    shareProperties = Column(JSON)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            [source, docID],
+            [Document.source, Document.docID]
+        ), {}
+    )
+
+
+class Contributor(Base):
+    __tablename__ = 'contributors'
+
+    # TODO: Need a sane primary key for contributors
+    # This just creates a lot of duplication when reprocessing
+    id = Column(Integer, primary_key=True)
+
+    name = Column(String)
+    givenName = Column(String)
+    additionalName = Column(String)
+    familyName = Column(String)
+
+    email = Column(String)
+    affiliation = Column(String)  # Or do we want an institutions table?
+
+    sameAs = Column(ARRAY(String))
+
+
+class Organization(Base):
+    '''A model describing an organization
+    '''  # TODO: This is not currently disambiguated in our schema
+    __tablename__ = 'organizations'
+
+    # TODO: Good identifier for an organization?
+    # Name is much more likely to be unique
+    id = Column(Integer, primary_key=True)
+
+    name = Column(String)
+    email = Column(String)
+    sameAs = Column(ARRAY(String))
+
+
+class Log(Base):
+    __tablename__ = 'logs'
+
+    id = Column(Integer, primary_key=True)
+
+    document_source = Column(String)
+    document_docID = Column(String)
+
+    harvestStarted = Column(DateTime)
+    harvestFinished = Column(DateTime)
+    harvestTaskCreated = Column(DateTime)
+
+    normalizeStarted = Column(DateTime)
+    normalizeFinished = Column(DateTime)
+    normalizeTaskCreated = Column(DateTime)
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            [document_source, document_docID],
+            [Document.source, Document.docID]
+        ), {}
+    )

--- a/scrapi/requests.py
+++ b/scrapi/requests.py
@@ -56,7 +56,7 @@ def record_or_load_response(method, url, throttle=None, force=False, params=None
             encoding=response.encoding,
             status_code=response.status_code,
             headers_str=json.dumps(dict(response.headers))
-        )
+        ).save()
 
     logger.warning('Skipped recorded response from "{}"'.format(url))
 
@@ -66,7 +66,7 @@ def record_or_load_response(method, url, throttle=None, force=False, params=None
         encoding=response.encoding,
         status_code=response.status_code,
         headers_str=json.dumps(dict(response.headers))
-    )
+    ).save()
 
 
 def request(method, url, params=None, **kwargs):


### PR DESCRIPTION
TODO:
- [ ] Add tests
- [ ] Handle contributors better (right now there is a lot of duplication due to the versioning)
  - [ ] Also need to figure out how to handle the backref from contributors to documents (pointing to a bunch of versions seems kind of dumb...)
- [ ] Handle Organizations better (needs to be accompanied with change to schema, or at least to the backend representation of the schema)
- [ ] Figure out exactly what to do with versioning (right now a document points to a list of raw and normalized documents, which are the various versions we've encountered)
- [ ] Get postgres to handle the response processing
- [ ] Finish moving cassandra bits to the cassandra module
- [ ] Update/abstract migrations 
- [ ] Get deployment updates ready
- [x] update requirements