### PR TITLE
[hotfix] Update OSF harvester to honor period given to retract public registrations

### DIFF
--- a/scrapi/harvesters/osf.py
+++ b/scrapi/harvesters/osf.py
@@ -16,7 +16,6 @@ from datetime import date, timedelta
 from nameparser import HumanName
 
 from scrapi import requests
-from scrapi import settings
 from scrapi.base import JSONHarvester
 from scrapi.linter.document import RawDocument
 from scrapi.base.helpers import build_properties

--- a/scrapi/harvesters/osf.py
+++ b/scrapi/harvesters/osf.py
@@ -96,9 +96,10 @@ class OSFHarvester(JSONHarvester):
         }
 
     def harvest(self, start_date=None, end_date=None):
-
-        start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
-        end_date = end_date or date.today()
+        # Always harvest a 2 day period starting 2 days back to honor time given
+        # to contributors to cancel a public registration
+        start_date = start_date or date.today() - timedelta(4)
+        end_date = end_date or date.today() - timedelta(2)
 
         search_url = self.URL.format(start_date.isoformat(), end_date.isoformat())
         records = self.get_records(search_url)


### PR DESCRIPTION
Harvests will now automatically happen for a 2 day period starting 4 days in the past, to honor the 48 hours promised to contributors to public projects to make the registration private.