### PR TITLE
fix name for daily ssrn

### DIFF
--- a/scrapi/harvesters/dailyssrn.py
+++ b/scrapi/harvesters/dailyssrn.py
@@ -14,7 +14,7 @@ from scrapi.base.helpers import compose, single_result
 
 class DailyssrnHarvester(XMLHarvester):
     short_name = 'dailyssrn'
-    long_name = 'RSS Feed from the Social Science Research Network'
+    long_name = 'Social Science Research Network'
     url = 'http://papers.ssrn.com/'
 
     schema = {


### PR DESCRIPTION
Will require a reboot of the production box, + ```inv provider_map -d``` to remove the old name and replace it with this one.