### PR TITLE
Add raising a value error if no uri was returned for cannonical uri

### DIFF
--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -131,6 +131,7 @@ def oai_extract_url(identifiers):
                 return found_url
         except AttributeError:
             continue
+    raise ValueError('No Cannonical URI was returned for this record.')
 
 
 def oai_process_contributors(*args):

--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -131,7 +131,7 @@ def oai_extract_url(identifiers):
                 return found_url
         except AttributeError:
             continue
-    raise ValueError('No Cannonical URI was returned for this record.')
+    raise ValueError('No Canonical URI was returned for this record.')
 
 
 def oai_process_contributors(*args):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,4 +1,5 @@
 import vcr
+import pytest
 
 from scrapi.base import helpers
 
@@ -32,8 +33,8 @@ class TestHelpers(object):
 
     def test_oai_extract_url(self):
         identifiers = 'I might be a url but rly I am naaaahhttt'
-        extraction_attempt = helpers.oai_extract_url(identifiers)
-        extraction_attempt
+        with pytest.raises(ValueError):
+            helpers.oai_extract_url(identifiers)
 
     def test_process_contributors(self):
         args = ['Stardust Rhodes', 'Golddust Rhodes', 'Dusty Rhodes']


### PR DESCRIPTION
For OAI harvesters - a ValueError will be raised if no URI is returned for a particular record