### PR TITLE
Update many OAI URLs to point to real source pages

### DIFF
--- a/scrapi/harvesters/cyberleninka.py
+++ b/scrapi/harvesters/cyberleninka.py
@@ -11,7 +11,7 @@ from scrapi.base import OAIHarvester
 class CyberleninkaHarvester(OAIHarvester):
     short_name = 'cyberleninka'
     long_name = 'CyberLeninka - Russian open access scientific library'
-    url = 'http://cyberleninka.ru/oai'
+    url = 'http://cyberleninka.ru/'
     force_request_update = True
 
     namespaces = {

--- a/scrapi/harvesters/dash.py
+++ b/scrapi/harvesters/dash.py
@@ -11,7 +11,7 @@ from scrapi.base import OAIHarvester
 class DashHarvester(OAIHarvester):
     short_name = 'dash'
     long_name = 'Digital Access to Scholarship at Harvard'
-    url = 'http://dash.harvard.edu/oai/request'
+    url = 'http://dash.harvard.edu'
 
     base_url = 'http://dash.harvard.edu/oai/request'
     property_list = ['date', 'relation', 'identifier', 'type', 'rights']

--- a/scrapi/harvesters/datacite.py
+++ b/scrapi/harvesters/datacite.py
@@ -12,7 +12,7 @@ from scrapi.base.helpers import updated_schema, oai_extract_dois
 class DataciteHarvester(OAIHarvester):
     short_name = 'datacite'
     long_name = 'DataCite MDS'
-    url = 'http://oai.datacite.org/oai'
+    url = 'http://oai.datacite.org/'
 
     base_url = 'http://oai.datacite.org/oai'
     property_list = ['date', 'identifier', 'setSpec', 'description']

--- a/scrapi/harvesters/digitalhoward.py
+++ b/scrapi/harvesters/digitalhoward.py
@@ -11,7 +11,7 @@ from scrapi.base import OAIHarvester
 class HowardHarvester(OAIHarvester):
     short_name = 'digitalhoward'
     long_name = 'Digital Howard @ Howard University'
-    url = 'http://dh.howard.edu/do/oai/'
+    url = 'http://dh.howard.edu'
 
     base_url = 'http://dh.howard.edu/do/oai/'
     property_list = ['date', 'source', 'identifier', 'type', 'rights']

--- a/scrapi/harvesters/dryad.py
+++ b/scrapi/harvesters/dryad.py
@@ -31,7 +31,7 @@ def format_dois_dryad(*args):
 class DryadHarvester(OAIHarvester):
     short_name = 'dryad'
     long_name = 'Dryad Data Repository'
-    url = 'http://www.datadryad.org/oai/request'
+    url = 'http://www.datadryad.org/'
 
     base_url = 'http://www.datadryad.org/oai/request'
     property_list = ['rights', 'format', 'relation', 'date',

--- a/scrapi/harvesters/hacettepe.py
+++ b/scrapi/harvesters/hacettepe.py
@@ -11,7 +11,7 @@ from scrapi.base import OAIHarvester
 class HacettepeHarvester(OAIHarvester):
     short_name = 'hacettepe'
     long_name = 'Hacettepe University DSpace on LibLiveCD'
-    url = 'http://bbytezarsivi.hacettepe.edu.tr/oai/request'
+    url = 'http://bbytezarsivi.hacettepe.edu.tr'
 
     base_url = 'http://bbytezarsivi.hacettepe.edu.tr/oai/request'
     property_list = ['date', 'identifier', 'type', 'rights']

--- a/scrapi/harvesters/icpsr.py
+++ b/scrapi/harvesters/icpsr.py
@@ -12,7 +12,7 @@ from scrapi.base import OAIHarvester
 class IcpsrHarvester(OAIHarvester):
     short_name = 'icpsr'
     long_name = 'Inter-University Consortium for Political and Social Research'
-    url = 'http://www.icpsr.umich.edu/icpsrweb/ICPSR/oai/studies'
+    url = 'http://www.icpsr.umich.edu/'
 
     @property
     def schema(self):

--- a/scrapi/harvesters/iowaresearch.py
+++ b/scrapi/harvesters/iowaresearch.py
@@ -11,7 +11,7 @@ from scrapi.base import OAIHarvester
 class IowaresearchHarvester(OAIHarvester):
     short_name = 'iowaresearch'
     long_name = 'Iowa Research Online'
-    url = 'http://ir.uiowa.edu/do/oai/'
+    url = 'http://ir.uiowa.edu'
 
     base_url = 'http://ir.uiowa.edu/do/oai/'
     property_list = ['date', 'source', 'identifier', 'type']

--- a/scrapi/harvesters/mblwhoilibrary.py
+++ b/scrapi/harvesters/mblwhoilibrary.py
@@ -12,7 +12,7 @@ from scrapi.base import OAIHarvester
 class MblwhoilibraryHarvester(OAIHarvester):
     short_name = 'mblwhoilibrary'
     long_name = 'WHOAS at MBLWHOI Library'
-    url = 'http://darchive.mblwhoilibrary.org/oai/request'
+    url = 'http://darchive.mblwhoilibrary.org'
 
     @property
     def schema(self):

--- a/scrapi/harvesters/scholarworks_umass.py
+++ b/scrapi/harvesters/scholarworks_umass.py
@@ -11,7 +11,7 @@ from scrapi.base import OAIHarvester
 class ScholarworksumassHarvester(OAIHarvester):
     short_name = 'scholarworks_umass'
     long_name = 'ScholarWorks@UMass Amherst'
-    url = 'http://scholarworks.umass.edu/do/oai/'
+    url = 'http://scholarworks.umass.edu'
 
     base_url = 'http://scholarworks.umass.edu/do/oai/'
     property_list = ['date', 'source', 'identifier', 'type', 'format']

--- a/scrapi/harvesters/smithsonian.py
+++ b/scrapi/harvesters/smithsonian.py
@@ -14,7 +14,7 @@ from scrapi.base import OAIHarvester
 class SiHarvester(OAIHarvester):
     short_name = 'smithsonian'
     long_name = 'Smithsonian Digital Repository'
-    url = 'http://repository.si.edu/oai/request'
+    url = 'http://repository.si.edu'
 
     @property
     def schema(self):

--- a/scrapi/harvesters/wustlopenscholarship.py
+++ b/scrapi/harvesters/wustlopenscholarship.py
@@ -11,7 +11,7 @@ from scrapi.base import OAIHarvester
 class WustlopenscholarshipHarvester(OAIHarvester):
     short_name = 'wustlopenscholarship'
     long_name = 'Washington University Open Scholarship'
-    url = 'http://openscholarship.wustl.edu/do/oai/'
+    url = 'http://openscholarship.wustl.edu'
 
     base_url = 'http://openscholarship.wustl.edu/do/oai/'
     property_list = ['date', 'source', 'identifier', 'type', 'format', 'setSpec']


### PR DESCRIPTION
## Purpose 
The Auto-OAI harvest creator was not saving correct urls that are saved to the provider map - instead, was using the base OAI urls that usually don't direct anywhere useful.

This PR updates those that I found to be actual home pages for sources.

## Changes
One line in a bunch of different harvesters.  This really should only affect the SHARE OSF search page - clicking on the sources in each search result - along with the SHARE registration page that has the sources listed. 