### PR TITLE
Feature/clean data on validation

### DIFF
--- a/normalized.json
+++ b/normalized.json
@@ -3,348 +3,348 @@
         "person": {
             "required": [
                 "name"
-            ], 
-            "type": "object", 
-            "description": "A person that is a contributor to the research object.", 
+            ],
+            "type": "object",
+            "description": "A person that is a contributor to the research object.",
             "properties": {
                 "affiliation": {
                     "items": {
                         "$ref": "#/definitions/organization"
-                    }, 
-                    "type": "array", 
+                    },
+                    "type": "array",
                     "description": "The organization(s) that this person is affiliated with. For example, a school/university."
-                }, 
+                },
                 "givenName": {
-                    "type": "string", 
+                    "type": "string",
                     "description": "Also called the \"first name\", this element is preferred over using the combined \"name\" field."
-                }, 
+                },
                 "additionalName": {
-                    "type": "string", 
+                    "type": "string",
                     "description": "Also called the \"middle name\", this element will be derived from the creator.name by SHARE if not supplied by the source."
-                }, 
+                },
                 "name": {
-                    "type": "string", 
+                    "type": "string",
                     "description": "The name of the person if familyName, givenName, and/or additionalName."
-                }, 
+                },
                 "sameAs": {
                     "items": {
-                        "type": "string", 
-                        "description": "An HTTP URI that describes the person.", 
+                        "type": "string",
+                        "description": "An HTTP URI that describes the person.",
                         "format": "uri"
-                    }, 
-                    "type": "array", 
+                    },
+                    "type": "array",
                     "description": "An array of identifiers expressed as HTTP URIs that describe the person. For example, an ORCID, ResearcherID, arXiv author ID, ScopusID,  ISNI, or other unique identifier expressed as an HTTP URI."
-                }, 
+                },
                 "familyName": {
-                    "type": "string", 
+                    "type": "string",
                     "description": "Also called the \"last name\", this element is preferred over using the combined \"name\" field."
-                }, 
+                },
                 "email": {
-                    "type": "string", 
-                    "description": "The email address for this person.", 
+                    "type": "string",
+                    "description": "The email address for this person.",
                     "format": "email"
                 }
             }
-        }, 
+        },
         "sponsor": {
             "required": [
                 "sponsorName"
-            ], 
-            "type": "object", 
-            "description": "This describes the sponsor of the resource.", 
+            ],
+            "type": "object",
+            "description": "This describes the sponsor of the resource.",
             "properties": {
                 "sponsorName": {
-                    "type": "string", 
+                    "type": "string",
                     "description": "The name of the entity responsible for sponsoring the resource, recorded here as text."
-                }, 
+                },
                 "sponsorIdentifier": {
-                    "type": "string", 
-                    "description": "A globally unique identifier for the sponsor of the resource should be recorded here.", 
+                    "type": "string",
+                    "description": "A globally unique identifier for the sponsor of the resource should be recorded here.",
                     "format": "uri"
                 }
             }
-        }, 
+        },
         "license": {
             "required": [
                 "uri"
-            ], 
-            "type": "object", 
+            ],
+            "type": "object",
             "properties": {
                 "startDate": {
-                    "type": "string", 
-                    "description": "The date and time at which the license will apply to this object. If the resource was always licensed this way, then this date can be omitted.", 
+                    "type": "string",
+                    "description": "The date and time at which the license will apply to this object. If the resource was always licensed this way, then this date can be omitted.",
                     "format": "date-time"
-                }, 
+                },
                 "endDate": {
-                    "type": "string", 
-                    "description": "The date and time at which this resource will no longer be licensed in this way.", 
+                    "type": "string",
+                    "description": "The date and time at which this resource will no longer be licensed in this way.",
                     "format": "date-time"
-                }, 
+                },
                 "uri": {
-                    "type": "string", 
-                    "description": "The HTTP URI of the license of the object or--if startDate and endDate are included--in effect during the period listed.", 
+                    "type": "string",
+                    "description": "The HTTP URI of the license of the object or--if startDate and endDate are included--in effect during the period listed.",
                     "format": "uri"
-                }, 
+                },
                 "description": {
-                    "type": "string", 
+                    "type": "string",
                     "description": "Text describing to what aspect of the object the license is applied."
                 }
             }
-        }, 
+        },
         "organization": {
             "required": [
                 "name"
-            ], 
-            "type": "object", 
-            "description": "An organization or institution.", 
+            ],
+            "type": "object",
+            "description": "An organization or institution.",
             "properties": {
                 "sameAs": {
                     "items": {
-                        "type": "string", 
-                        "description": "A single HTTP URI that describes this organization", 
+                        "type": "string",
+                        "description": "A single HTTP URI that describes this organization",
                         "format": "uri"
-                    }, 
-                    "type": "array", 
+                    },
+                    "type": "array",
                     "description": "Identifiers that describe this organization"
-                }, 
+                },
                 "name": {
-                    "type": "string", 
+                    "type": "string",
                     "description": "The name of the organization."
-                }, 
+                },
                 "email": {
-                    "type": "string", 
-                    "description": "An email address for this organization", 
+                    "type": "string",
+                    "description": "An email address for this organization",
                     "format": "uri"
                 }
             }
-        }, 
+        },
         "otherProperties": {
             "required": [
-                "name", 
+                "name",
                 "properties"
-            ], 
-            "type": "object", 
+            ],
+            "type": "object",
             "properties": {
                 "description": {
-                    "type": "string", 
+                    "type": "string",
                     "description": "A description of this collection of properties."
-                }, 
+                },
                 "properties": {
-                    "type": "object", 
+                    "type": "object",
                     "description": "The collection of key/value pair properties."
-                }, 
+                },
                 "name": {
-                    "type": "string", 
+                    "type": "string",
                     "description": "A name that describes this collection of properties."
-                }, 
+                },
                 "uri": {
-                    "type": "string", 
-                    "description": "A URI that points to the definition, schema, and/or vocabulary of this entry.", 
+                    "type": "string",
+                    "description": "A URI that points to the definition, schema, and/or vocabulary of this entry.",
                     "format": "uri"
                 }
             }
-        }, 
+        },
         "award": {
             "required": [
                 "awardName"
-            ], 
-            "type": "object", 
-            "description": "The award made in support of the object.", 
+            ],
+            "type": "object",
+            "description": "The award made in support of the object.",
             "properties": {
                 "awardIdentifier": {
-                    "type": "string", 
-                    "description": "An HTTP URI for the award.", 
+                    "type": "string",
+                    "description": "An HTTP URI for the award.",
                     "format": "uri"
-                }, 
+                },
                 "awardName": {
-                    "type": "string", 
+                    "type": "string",
                     "description": "The textual representation of the award identifier as issued by the sponsor."
                 }
             }
-        }, 
+        },
         "sponsorship": {
             "required": [
                 "sponsor"
-            ], 
-            "type": "object", 
-            "description": "A sponsorship associated with the resource.", 
+            ],
+            "type": "object",
+            "description": "A sponsorship associated with the resource.",
             "properties": {
                 "sponsor": {
                     "$ref": "#/definitions/sponsor"
-                }, 
+                },
                 "award": {
                     "$ref": "#/definitions/award"
                 }
             }
         }
-    }, 
-    "$schema": "http://json-schema.org/draft-04/schema#", 
+    },
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "required": [
-        "title", 
-        "contributors", 
-        "uris", 
+        "title",
+        "contributors",
+        "uris",
         "providerUpdatedDateTime"
-    ], 
-    "type": "object", 
+    ],
+    "type": "object",
     "properties": {
         "publisher": {
-            "type": "object", 
+            "type": "object",
             "anyOf": [
                 {
                     "$ref": "#/definitions/person"
-                }, 
+                },
                 {
                     "$ref": "#/definitions/organization"
                 }
-            ], 
+            ],
             "description": "This element contains the name of the entity, typically a 'publisher', responsible for making the version of record of the resource available. This could be a person, organisation or service"
-        }, 
+        },
         "description": {
-            "type": "string", 
+            "type": "string",
             "description": "A textual description of the resource."
-        }, 
+        },
         "contributors": {
             "items": {
                 "anyOf": [
                     {
                         "$ref": "#/definitions/person"
-                    }, 
+                    },
                     {
                         "$ref": "#/definitions/organization"
                     }
                 ]
-            }, 
-            "type": "array", 
+            },
+            "type": "array",
             "description": "The people or organizations responsible for making contributions to an object."
-        }, 
+        },
         "title": {
-            "type": "string", 
+            "type": "string",
             "description": "The title and any sub-titles of the resource."
-        }, 
+        },
         "shareProperties": {
-            "type": "object", 
+            "type": "object",
             "description": "Properties that are generated and/or organized by the SHARE system (e.g., timestamps of when SHARE processes data). These properities are used internally and are not guaranteed to remain consistent."
-        }, 
+        },
         "otherProperties": {
             "items": {
                 "$ref": "#/definitions/otherProperties"
-            }, 
-            "type": "array", 
+            },
+            "type": "array",
             "description": "Any structured or unstructured properties (properties that do or do not include URIs to definitions) that do not fall into the schema provided."
-        }, 
+        },
         "tags": {
             "items": {
                 "type": "string"
-            }, 
-            "type": "array", 
+            },
+            "type": "array",
             "description": "Non-hierarchical terms or keywords assigned to an object to aid browsing or searching."
-        }, 
+        },
         "uris": {
-            "type": "object", 
+            "type": "object",
             "properties": {
                 "anyOf": {
                     "canonicalUri": {
-                        "type": "string", 
-                        "description": "The preferred persistent HTTP URI that represents the research object. This should be repeated in exactly one other field in the uris object.", 
+                        "type": "string",
+                        "description": "The preferred persistent HTTP URI that represents the research object. This should be repeated in exactly one other field in the uris object.",
                         "format": "uri"
-                    }, 
+                    },
                     "providerUris": {
                         "items": {
-                            "type": "string", 
+                            "type": "string",
                             "format": "uri"
-                        }, 
-                        "type": "array", 
+                        },
+                        "type": "array",
                         "description": "The persistent HTTP URI that points to the object's record at the SHARE provider regardless of format."
-                    }, 
+                    },
                     "descriptorUris": {
                         "items": {
-                            "type": "string", 
+                            "type": "string",
                             "format": "uri"
-                        }, 
-                        "type": "array", 
+                        },
+                        "type": "array",
                         "description": "A persistent HTTP URI that points to a description of the research object."
-                    }, 
+                    },
                     "objectUris": {
                         "items": {
-                            "type": "string", 
+                            "type": "string",
                             "format": "uri"
-                        }, 
-                        "type": "array", 
+                        },
+                        "type": "array",
                         "description": "A persistent HTTP URI that points directly to the research object."
                     }
                 }
             }
-        }, 
+        },
         "languages": {
             "items": {
                 "pattern": "[a-z][a-z]?[a-z]",
                 "type": ["string", "null"]
-            }, 
-            "type": "array", 
+            },
+            "type": "array",
             "description": "The primary languages in which the content of the resource is presented. Values used for this element MUST conform to ISO 639\u20133. This offers two and three letter tags e.g. \"en\" or \"eng\" for English and \"en-GB\" for English used in the UK."
-        }, 
+        },
         "providerUpdatedDateTime": {
-            "type": "string", 
-            "description": "The date and time the provider describing the object has been updated about either the creation or update of an object by its contributors. E.g., this may be the date a manuscript is published, but not necessarily the date the manuscript was written.", 
+            "type": "string",
+            "description": "The date and time the provider describing the object has been updated about either the creation or update of an object by its contributors. E.g., this may be the date a manuscript is published, but not necessarily the date the manuscript was written.",
             "format": "date-time"
-        }, 
+        },
         "sponsorships": {
             "items": {
                 "$ref": "#/definitions/sponsorship"
-            }, 
-            "type": "array", 
+            },
+            "type": "array",
             "description": "Sponsorships associated with the object"
-        }, 
+        },
         "version": {
-            "type": "object", 
-            "description": "Infomation about this version of the object.", 
+            "type": "object",
+            "description": "Infomation about this version of the object.",
             "properties": {
                 "versionId": {
                     "description": "The name or number representing this version of the object."
-                }, 
+                },
                 "versionDateTime": {
-                    "type": "string", 
-                    "description": "The date and time the object was created or updated by its contributors. If the data for the object describes the first version of that object, it will be the date and time of object creation, otherwise it will be considered the date and time the object was updated.", 
+                    "type": "string",
+                    "description": "The date and time the object was created or updated by its contributors. If the data for the object describes the first version of that object, it will be the date and time of object creation, otherwise it will be considered the date and time the object was updated.",
                     "format": "date-time"
-                }, 
+                },
                 "versionOf": {
-                    "type": "string", 
-                    "description": "If the object is an update, the HTTP URI of the object the content is updating. Depending upon what the upate is relative to, that could be the object at creation or a previous version.", 
+                    "type": "string",
+                    "description": "If the object is an update, the HTTP URI of the object the content is updating. Depending upon what the upate is relative to, that could be the object at creation or a previous version.",
                     "format": "uri"
                 }
             }
-        }, 
+        },
         "freeToRead": {
             "required": [
                 "startDate"
-            ], 
-            "type": "object", 
-            "description": "A date range specifying when this research object will be accessible, without restrictsions such as fee or registration). If the object is free to read, then only the startDate is required.", 
+            ],
+            "type": "object",
+            "description": "A date range specifying when this research object will be accessible, without restrictsions such as fee or registration). If the object is free to read, then only the startDate is required.",
             "properties": {
                 "startDate": {
-                    "type": ["string", "null"], 
-                    "description": "The date and time at which the object will be accessible. If the resource was always free to read, then the date the object was created should be used.", 
+                    "type": ["string", "null"],
+                    "description": "The date and time at which the object will be accessible. If the resource was always free to read, then the date the object was created should be used.",
                     "format": "date"
-                }, 
+                },
                 "endDate": {
-                    "type": "string", 
-                    "description": "The date and time at which restrictions such as fees or registrations will be in place limiting accessibility.", 
+                    "type": "string",
+                    "description": "The date and time at which restrictions such as fees or registrations will be in place limiting accessibility.",
                     "format": "date"
                 }
             }
-        }, 
+        },
         "licenses": {
             "items": {
                 "$ref": "#/definitions/license"
-            }, 
-            "type": "array", 
+            },
+            "type": "array",
             "description": "The licenses under which the object has been released."
-        }, 
+        },
         "subjects": {
             "items": {
                 "type": "string"
-            }, 
-            "type": "array", 
+            },
+            "type": "array",
             "description": "The topic or domain of the object. Follows recommendations of http://dublincore.org/documents/2012/06/14/dcmi-terms/?v=elements#terms-subject"
         }
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 lxml==3.4.0
 pytz==2014.7
-vcrpy==1.1.1
+vcrpy==1.7.1
 raven==5.0.0
 invoke==0.9.0
 celery==3.1.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,5 @@ furl==0.4.4
 jsonschema==2.4.0
 jsonpointer==1.7
 pycountry==1.10
+rfc3987==1.3.4
+strict-rfc3339==0.5

--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -83,7 +83,7 @@ class JSONHarvester(BaseHarvester, JSONTransformer):
         transformed['shareProperties'] = {
             'source': self.short_name
         }
-        return NormalizedDocument(transformed)
+        return NormalizedDocument(transformed, clean=True)
 
 
 class XMLHarvester(BaseHarvester, XMLTransformer):
@@ -94,7 +94,7 @@ class XMLHarvester(BaseHarvester, XMLTransformer):
         transformed['shareProperties'] = {
             'source': self.short_name
         }
-        return NormalizedDocument(transformed)
+        return NormalizedDocument(transformed, clean=True)
 
 
 class OAIHarvester(XMLHarvester):

--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import re
+import pytz
 import functools
 from copy import deepcopy
 
@@ -8,6 +9,7 @@ import six
 from lxml import etree
 from pycountry import languages
 from nameparser import HumanName
+from dateutil import parser
 
 from scrapi import requests
 
@@ -81,8 +83,6 @@ def default_name_parser(names):
             'givenName': name.first,
             'additionalName': name.middle,
             'familyName': name.last,
-            'email': '',
-            'sameAs': []
         }
         contributor_list.append(contributor)
 
@@ -196,3 +196,10 @@ def extract_doi_from_text(identifiers):
             return 'http://dx.doi.org/{}'.format(found_url.replace('doi:', ''))
         except AttributeError:
             continue
+
+
+def date_formatter(date_string):
+    date_time = parser.parse(date_string)
+    if not date_time.tzinfo:
+        date_time = date_time.replace(tzinfo=pytz.UTC)
+    return date_time.isoformat()

--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -1,15 +1,15 @@
 from __future__ import unicode_literals
 
 import re
-import pytz
 import functools
 from copy import deepcopy
 
 import six
+import pytz
 from lxml import etree
+from dateutil import parser
 from pycountry import languages
 from nameparser import HumanName
-from dateutil import parser
 
 from scrapi import requests
 
@@ -199,6 +199,9 @@ def extract_doi_from_text(identifiers):
 
 
 def date_formatter(date_string):
+    '''Takes an arbitrary date/time string and parses it, adds time
+    zone information and returns a valid ISO-8601 datetime string
+    '''
     date_time = parser.parse(date_string)
     if not date_time.tzinfo:
         date_time = date_time.replace(tzinfo=pytz.UTC)

--- a/scrapi/base/schemas.py
+++ b/scrapi/base/schemas.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-from dateutil.parser import parse
-
 from .helpers import (
     compose,
     format_tags,
@@ -59,7 +57,7 @@ OAISCHEMA = {
         "canonicalUri": ('//dc:identifier/node()', oai_extract_url),
         "objectUris": ('//dc:doi/node()', '//dc:identifier/node()', oai_extract_dois)
     },
-    'providerUpdatedDateTime': ('//ns0:header/ns0:datestamp/node()', lambda x: date_formatter(x[0])), #parse(x[0]).isoformat()),
+    'providerUpdatedDateTime': ('//ns0:header/ns0:datestamp/node()', compose(date_formatter, single_result)),
     'title': ('//dc:title/node()', single_result),
     'description': ('//dc:description/node()', single_result),
     'subjects': ('//dc:subject/node()', format_tags),

--- a/scrapi/base/schemas.py
+++ b/scrapi/base/schemas.py
@@ -5,8 +5,9 @@ from dateutil.parser import parse
 from .helpers import (
     compose,
     format_tags,
-    language_codes,
     single_result,
+    language_codes,
+    date_formatter,
     oai_extract_url,
     oai_extract_dois,
     build_properties,
@@ -19,7 +20,7 @@ DOESCHEMA = {
     "description": ('//dc:description/node()', compose(lambda x: x.strip(), single_result)),
     "contributors": ('//dc:creator/node()', compose(default_name_parser, lambda x: x.split(';'), single_result)),
     "title": ('//dc:title/node()', compose(lambda x: x.strip(), single_result)),
-    "providerUpdatedDateTime": ('//dc:dateEntry/node()', compose(lambda x: x.isoformat(), parse, lambda x: x.strip(), single_result)),
+    "providerUpdatedDateTime": ('//dc:dateEntry/node()', compose(date_formatter, single_result)),
     "uris": {
         "canonicalUri": ('//dcq:identifier-citation/node()', compose(lambda x: x.strip(), single_result)),
         "objectUris": [('//dc:doi/node()', compose(lambda x: 'http://dx.doi.org/' + x, single_result))]
@@ -58,7 +59,7 @@ OAISCHEMA = {
         "canonicalUri": ('//dc:identifier/node()', oai_extract_url),
         "objectUris": ('//dc:doi/node()', '//dc:identifier/node()', oai_extract_dois)
     },
-    'providerUpdatedDateTime': ('//ns0:header/ns0:datestamp/node()', lambda x: parse(x[0]).replace(tzinfo=None).isoformat()),
+    'providerUpdatedDateTime': ('//ns0:header/ns0:datestamp/node()', lambda x: date_formatter(x[0])), #parse(x[0]).isoformat()),
     'title': ('//dc:title/node()', single_result),
     'description': ('//dc:description/node()', single_result),
     'subjects': ('//dc:subject/node()', format_tags),

--- a/scrapi/harvesters/bhl.py
+++ b/scrapi/harvesters/bhl.py
@@ -12,7 +12,6 @@ def institution_name_parser(names):
     for inst in names:
         contributor = {
             'name': inst,
-            'email': '',
             'sameAs': []
         }
         contributor_list.append(contributor)

--- a/scrapi/harvesters/biomedcentral.py
+++ b/scrapi/harvesters/biomedcentral.py
@@ -19,7 +19,8 @@ from scrapi import requests
 from scrapi import settings
 from scrapi.base import JSONHarvester
 from scrapi.linter.document import RawDocument
-from scrapi.base.helpers import build_properties
+from scrapi.base.helpers import build_properties, date_formatter
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,7 +41,6 @@ def process_contributors(authors):
             'givenName': name.first,
             'additionalName': name.middle,
             'familyName': name.last,
-            'email': '',
             'sameAs': [],
         }
         contributor_list.append(contributor)
@@ -65,7 +65,7 @@ class BiomedCentralHarvester(JSONHarvester):
                 'objectUris': ('/doi', lambda x: ['http://dx.doi.org/' + x])
             },
             'title': ('/bibliographyTitle', '/blurbTitle', lambda x, y: x or y),
-            'providerUpdatedDateTime': ('/published Date', lambda x: parse(x).isoformat()),
+            'providerUpdatedDateTime': ('/published Date', lambda x: date_formatter(x)),
             'description': '/blurbText',
             'freeToRead': {
                 'startDate': ('/is_free', '/published Date', lambda x, y: y if x else None)

--- a/scrapi/harvesters/biomedcentral.py
+++ b/scrapi/harvesters/biomedcentral.py
@@ -11,7 +11,6 @@ from __future__ import unicode_literals
 import json
 import logging
 from datetime import date, timedelta
-from dateutil.parser import parse
 
 from nameparser import HumanName
 

--- a/scrapi/harvesters/clinicaltrials.py
+++ b/scrapi/harvesters/clinicaltrials.py
@@ -13,7 +13,6 @@ import logging
 from datetime import date, timedelta
 
 from lxml import etree
-from dateutil.parser import parse
 
 from scrapi import requests
 from scrapi import settings

--- a/scrapi/harvesters/clinicaltrials.py
+++ b/scrapi/harvesters/clinicaltrials.py
@@ -21,7 +21,7 @@ from scrapi.base import XMLHarvester
 from scrapi.util import copy_to_unicode
 from scrapi.linter.document import RawDocument
 from scrapi.base.schemas import default_name_parser
-from scrapi.base.helpers import compose, single_result, build_properties
+from scrapi.base.helpers import compose, single_result, build_properties, date_formatter
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ class ClinicalTrialsHarvester(XMLHarvester):
         "uris": {
             "canonicalUri": ("//required_header/url/node()", single_result)
         },
-        "providerUpdatedDateTime": ("lastchanged_date/node()", compose(lambda x: parse(x).replace(tzinfo=None).isoformat(), single_result)),
+        "providerUpdatedDateTime": ("lastchanged_date/node()", compose(date_formatter, single_result)),
         "title": ('//official_title/node()', '//brief_title/node()', lambda x, y: single_result(x) or single_result(y)),
         "description": ('//brief_summary/textblock/node()', '//brief_summary/textblock/node()', lambda x, y: single_result(x) or single_result(y)),
         "tags": ("//keyword/node()", lambda tags: [tag.lower() for tag in tags]),

--- a/scrapi/harvesters/crossref.py
+++ b/scrapi/harvesters/crossref.py
@@ -13,7 +13,6 @@ from datetime import date, timedelta
 
 from six.moves import xrange
 from nameparser import HumanName
-from dateutil.parser import parse
 
 from scrapi import requests
 from scrapi import settings

--- a/scrapi/harvesters/crossref.py
+++ b/scrapi/harvesters/crossref.py
@@ -30,10 +30,8 @@ def process_contributor(author, orcid):
         'givenName': name.first,
         'additionalName': name.middle,
         'familyName': name.last,
-        'sameAs': []
+        'sameAs': [orcid] if orcid else []
     }
-    if orcid:
-        ret['sameAs'].append(orcid)
     return ret
 
 

--- a/scrapi/harvesters/crossref.py
+++ b/scrapi/harvesters/crossref.py
@@ -19,21 +19,23 @@ from scrapi import requests
 from scrapi import settings
 from scrapi.base import JSONHarvester
 from scrapi.linter.document import RawDocument
-from scrapi.base.helpers import build_properties, compose
+from scrapi.base.helpers import build_properties, compose, date_formatter
 
 logger = logging.getLogger(__name__)
 
 
 def process_contributor(author, orcid):
     name = HumanName(author)
-    return {
+    ret = {
         'name': author,
         'givenName': name.first,
         'additionalName': name.middle,
         'familyName': name.last,
-        'email': '',
-        'sameAs': [orcid or '']
+        'sameAs': []
     }
+    if orcid:
+        ret['sameAs'].append(orcid)
+    return ret
 
 
 class CrossRefHarvester(JSONHarvester):
@@ -50,7 +52,7 @@ class CrossRefHarvester(JSONHarvester):
         return {
             'title': ('/title', lambda x: x[0] if x else ''),
             'description': ('/subtitle', lambda x: x[0] if (isinstance(x, list) and x) else x or ''),
-            'providerUpdatedDateTime': ('/issued/date-parts', lambda x: parse(' '.join([str(part) for part in x[0]])).date().isoformat()),
+            'providerUpdatedDateTime': ('/issued/date-parts', compose(date_formatter, lambda x: ' '.join([str(part) for part in x[0]]))),
             'uris': {
                 'canonicalUri': '/URL'
             },

--- a/scrapi/harvesters/datacite.py
+++ b/scrapi/harvesters/datacite.py
@@ -6,7 +6,7 @@ Example API call: http://oai.datacite.org/oai?verb=ListRecords&metadataPrefix=oa
 from __future__ import unicode_literals
 
 from scrapi.base import OAIHarvester
-from scrapi.base.helpers import updated_schema, oai_extract_dois
+from scrapi.base.helpers import updated_schema, oai_extract_dois, compose, single_result
 
 
 class DataciteHarvester(OAIHarvester):
@@ -23,7 +23,7 @@ class DataciteHarvester(OAIHarvester):
         return updated_schema(self._schema, {
             "description": ("//dc:description/node()", get_second_description),
             "uris": {
-                "canonicalUri": ('//dc:identifier/node()', oai_extract_dois),
+                "canonicalUri": ('//dc:identifier/node()', compose(single_result, oai_extract_dois)),
                 "objectUris": ('//dc:identifier/node()', oai_extract_dois)
             }
         })

--- a/scrapi/harvesters/dataone.py
+++ b/scrapi/harvesters/dataone.py
@@ -10,7 +10,6 @@ import re
 import logging
 from datetime import timedelta, date
 
-import six
 from lxml import etree
 from dateutil.parser import parse
 from xml.etree import ElementTree
@@ -22,7 +21,7 @@ from scrapi import settings
 from scrapi.base import XMLHarvester
 from scrapi.util import copy_to_unicode
 from scrapi.linter.document import RawDocument
-from scrapi.base.helpers import compose, single_result, build_properties
+from scrapi.base.helpers import compose, single_result, build_properties, date_formatter
 
 logger = logging.getLogger(__name__)
 
@@ -87,8 +86,9 @@ def process_contributors(author, submitters, contributors,
                 'givenName': name.first,
                 'additionalName': name.middle,
                 'familyName': name.last,
-                'email': six.text_type(email)
             }
+            if email:
+                contributor_dict['email'] = email
             contributor_list.append(contributor_dict)
         else:
             name = HumanName(contributor)
@@ -150,7 +150,7 @@ class DataOneHarvester(XMLHarvester):
             'objectUri': ("arr[@name='resourceMap']/str/node()", compose(lambda x: x.replace('doi:', 'http://dx.doi.org/'), single_result))
         },
         'tags': ("//arr[@name='keywords']/str/node()", lambda x: x if isinstance(x, list) else [x]),
-        'providerUpdatedDateTime': ("str[@name='dateModified']/node()", compose(lambda x: parse(x).date().isoformat(), single_result)),
+        'providerUpdatedDateTime': ("str[@name='dateModified']/node()", compose(date_formatter, single_result)),
         'title': ("str[@name='title']/node()", single_result),
         'description': ("str[@name='abstract']/node()", single_result)
     }

--- a/scrapi/harvesters/figshare.py
+++ b/scrapi/harvesters/figshare.py
@@ -19,7 +19,7 @@ from scrapi import requests
 from scrapi import settings
 from scrapi.base import JSONHarvester
 from scrapi.linter.document import RawDocument
-from scrapi.base.helpers import default_name_parser, build_properties
+from scrapi.base.helpers import default_name_parser, build_properties, date_formatter
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,7 @@ class FigshareHarvester(JSONHarvester):
         'title': '/title',
         'description': '/description',
         'contributors': ('/authors', lambda x: default_name_parser([person['author_name'] for person in x])),
-        'providerUpdatedDateTime': ('/modified_date', lambda x: parse(x).date().isoformat()),
+        'providerUpdatedDateTime': ('/modified_date', date_formatter),
         'uris': {
             'canonicalUri': ('/DOI', lambda x: x[0] if isinstance(x, list) else x),
             'providerUris': [
@@ -43,7 +43,7 @@ class FigshareHarvester(JSONHarvester):
             ]
         },
         'otherProperties': build_properties(
-            ('serviceID', ('/article_id', lambda x: str(x))),
+            ('serviceID', ('/article_id', str)),
             ('definedType', '/defined_type'),
             ('type', '/type'),
             ('links', '/links'),

--- a/scrapi/harvesters/figshare.py
+++ b/scrapi/harvesters/figshare.py
@@ -13,7 +13,6 @@ import logging
 from datetime import date, timedelta
 
 import six
-from dateutil.parser import parse
 
 from scrapi import requests
 from scrapi import settings

--- a/scrapi/harvesters/harvarddataverse.py
+++ b/scrapi/harvesters/harvarddataverse.py
@@ -12,13 +12,12 @@ from datetime import date
 from datetime import timedelta
 
 import furl
-from dateutil.parser import parse
 
 from scrapi import requests
 from scrapi import settings
 from scrapi.base import JSONHarvester
 from scrapi.linter.document import RawDocument
-from scrapi.base.helpers import default_name_parser, build_properties
+from scrapi.base.helpers import default_name_parser, build_properties, date_formatter
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +44,7 @@ class HarvardDataverseHarvester(JSONHarvester):
         'title': '/name',
         'description': '/description',
         'contributors': ('/authors', default_name_parser),
-        'providerUpdatedDateTime': ('/published_at', lambda x: parse(x).replace(tzinfo=None).isoformat()),
+        'providerUpdatedDateTime': ('/published_at', date_formatter),
         'uris': {
             'canonicalUri': '/url',
             'objectUris': [

--- a/scrapi/harvesters/osf.py
+++ b/scrapi/harvesters/osf.py
@@ -10,7 +10,6 @@ from __future__ import unicode_literals
 
 import json
 import logging
-from dateutil.parser import parse
 from datetime import date, timedelta
 
 from nameparser import HumanName

--- a/scrapi/harvesters/osf.py
+++ b/scrapi/harvesters/osf.py
@@ -18,7 +18,7 @@ from nameparser import HumanName
 from scrapi import requests
 from scrapi.base import JSONHarvester
 from scrapi.linter.document import RawDocument
-from scrapi.base.helpers import build_properties
+from scrapi.base.helpers import build_properties, date_formatter
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +33,6 @@ def process_contributors(authors):
             'givenName': name.first,
             'additionalName': name.middle,
             'familyName': name.last,
-            'email': '',
-            'sameAs': [],
         }
         contributor_list.append(contributor)
 
@@ -55,10 +53,6 @@ def process_tags(entry):
         return [entry]
 
 
-def parse_date(entry):
-    return parse(entry).date().isoformat()
-
-
 class OSFHarvester(JSONHarvester):
     short_name = 'osf'
     long_name = 'Open Science Framework'
@@ -67,7 +61,7 @@ class OSFHarvester(JSONHarvester):
 
     # Only registrations that aren't just the word "test" or "test project"
     URL = 'https://osf.io/api/v1/search/?q=category:registration ' +\
-          ' AND date_created:[{} TO {}]' +\
+          ' AND registered_date:[{} TO {}]' +\
           ' AND NOT title=test AND NOT title="Test Project"&size=1000'
 
     @property
@@ -75,7 +69,7 @@ class OSFHarvester(JSONHarvester):
         return {
             'contributors': ('/contributors', process_contributors),
             'title': ('/title', process_null),
-            'providerUpdatedDateTime': ('/date_created', parse_date),
+            'providerUpdatedDateTime': ('/date_registered', date_formatter),
             'description': ('/description', process_null),
             'uris': {
                 'canonicalUri': ('/url', lambda x: 'http://osf.io' + x),

--- a/scrapi/harvesters/plos.py
+++ b/scrapi/harvesters/plos.py
@@ -22,13 +22,12 @@ import logging
 from datetime import date, timedelta
 
 from lxml import etree
-from dateutil.parser import parse
 
 from scrapi import requests
 from scrapi import settings
 from scrapi.base import XMLHarvester
 from scrapi.linter.document import RawDocument
-from scrapi.base.helpers import default_name_parser, build_properties, compose, single_result
+from scrapi.base.helpers import default_name_parser, build_properties, compose, single_result, date_formatter
 
 logger = logging.getLogger(__name__)
 
@@ -101,7 +100,7 @@ class PlosHarvester(XMLHarvester):
             'canonicalUri': ('//str[@name="id"]/node()', compose('http://dx.doi.org/{}'.format, single_result)),
         },
         'contributors': ('//arr[@name="author_display"]/str/node()', default_name_parser),
-        'providerUpdatedDateTime': ('//date[@name="publication_data"]/node()', compose(lambda x: parse(x).date().isoformat(), single_result)),
+        'providerUpdatedDateTime': ('//date[@name="publication_data"]/node()', compose(date_formatter, single_result)),
         'title': ('//str[@name="title_display"]/node()', single_result),
         'description': ('//arr[@name="abstract"]/str/node()', single_result),
         'publisher': {

--- a/scrapi/linter/document.py
+++ b/scrapi/linter/document.py
@@ -10,14 +10,17 @@ from scrapi.util import json_without_bytes
 def strip_empty(document, required=tuple()):
     ''' Removes empty fields from the processed schema
     '''
+    new_doc = {}
     for k, v in document.items():
-        if k not in required:
-            document[k] = do_strip_empty(v)
+        if k in required:
+            new_doc[k] = v
+        else:
+            new_val = do_strip_empty(v)
             if k == 'otherProperties':
-                document[k] = [property for property in document[k] if property.get('properties')]
-            if not document[k]:
-                del document[k]
-    return document
+                new_val = [property for property in new_val if property.get('properties')]
+            if new_val:
+                new_doc[k] = new_val
+    return new_doc
 
 
 def strip_list(l):

--- a/scrapi/linter/document.py
+++ b/scrapi/linter/document.py
@@ -24,7 +24,7 @@ def strip_empty(document, required=tuple()):
 
 
 def strip_list(l):
-    return filter(lambda x: x, map(do_strip_empty, l))
+    return list(filter(lambda x: x, map(do_strip_empty, l)))
 
 
 def do_strip_empty(value):

--- a/scrapi/processing/cassandra.py
+++ b/scrapi/processing/cassandra.py
@@ -51,7 +51,7 @@ class CassandraProcessor(BaseProcessor):
             source=raw_doc['source'],
             docID=raw_doc['docID'],
             filetype=raw_doc['filetype'],
-            doc=six.binary_type(raw_doc['doc']),
+            doc=raw_doc['doc'].encode('utf-8'),
             timestamps=raw_doc.get('timestamps', {})
         ).save()
 

--- a/scrapi/processing/cassandra.py
+++ b/scrapi/processing/cassandra.py
@@ -4,7 +4,6 @@ import json
 import logging
 from uuid import uuid4
 
-import six
 from dateutil.parser import parse
 
 from cassandra.cqlengine import columns, models

--- a/scrapi/processing/cassandra.py
+++ b/scrapi/processing/cassandra.py
@@ -52,7 +52,7 @@ class CassandraProcessor(BaseProcessor):
             docID=raw_doc['docID'],
             filetype=raw_doc['filetype'],
             doc=six.binary_type(raw_doc['doc']),
-            timestamps=raw_doc['timestamps']
+            timestamps=raw_doc.get('timestamps', {})
         ).save()
 
     def send_to_database(self, docID, source, **kwargs):

--- a/scrapi/requests.py
+++ b/scrapi/requests.py
@@ -44,7 +44,11 @@ class HarvesterResponse(models.Model):
     time_made = columns.DateTime(default=datetime.now)
 
     def json(self):
-        return json.loads(self.content)
+        try:
+            content = self.content.decode('utf-8')
+        except AttributeError:  # python 3eeeee!
+            content = self.content
+        return json.loads(content)
 
     @property
     def headers(self):

--- a/tests/test_json_harvester.py
+++ b/tests/test_json_harvester.py
@@ -7,7 +7,7 @@ from dateutil.parser import parse
 
 from scrapi.base import JSONHarvester
 from scrapi.linter import RawDocument
-from scrapi.base.helpers import build_properties
+from scrapi.base.helpers import build_properties, date_formatter
 
 expected = {
     "description": "This is a  test",
@@ -17,23 +17,21 @@ expected = {
             "givenName": "Testy",
             "familyName": "Testerson",
             "additionalName": "",
-            "ORCID": None,
-            "email": ""
+            "sameAs": []
         },
         {
             "name": "Test Testerson Jr",
             "givenName": "Test",
             "familyName": "Testerson",
             "additionalName": "",
-            "ORCID": None,
-            "email": ""
+            "sameAs": []
         }
     ],
     "title": "Test",
     'uris': {
         "canonicalUri": "http://example.com"
     },
-    "providerUpdatedDateTime": "2015-02-02T00:00:00",
+    "providerUpdatedDateTime": "2015-02-02T00:00:00+00:00",
     "shareProperties": {
         "source": "test"
     },
@@ -55,18 +53,6 @@ expected = {
             "properties": {
                 "depositedTimestamp": "right now"
             }
-        },
-        {
-            "name": "Empty",
-            "properties": {
-                "Empty": None
-            }
-        },
-        {
-            "name": "Empty2",
-            "properties": {
-                "Empty2": None
-            }
         }
     ]
 }
@@ -79,8 +65,7 @@ def process_contributor(author, orcid):
         'givenName': name.first,
         'additionalName': name.middle,
         'familyName': name.last,
-        'email': '',
-        'ORCID': orcid
+        'sameAs': []
     }
 
 
@@ -98,9 +83,9 @@ class TestHarvester(JSONHarvester):
         return {
             'title': ('/title', lambda x: x[0] if x else ''),
             'description': ('/subtitle', lambda x: x[0] if (isinstance(x, list) and x) else x or ''),
-            'providerUpdatedDateTime': ('/issued/date-parts', lambda x: parse(' '.join(
-                [part for part in x[0]])).isoformat()
-            ),
+            'providerUpdatedDateTime': ('/issued/date-parts', lambda x: date_formatter(' '.join(
+                [part for part in x[0]])
+            )),
             'uris': {
                 'canonicalUri': '/URL'
             },

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,6 +1,7 @@
 import copy
 import pytest
 import mock
+import six
 
 import scrapi
 from scrapi.linter.document import NormalizedDocument
@@ -94,7 +95,10 @@ def test_renormalize():
 
 @pytest.mark.cassandra
 def test_migrate_v2():
-    RAW['doc'] = str(RAW['doc'])
+    try:
+        RAW['doc'] = RAW['doc'].encode('utf-8')
+    except AttributeError:
+        RAW['doc'] = str(RAW['doc'])
     DocumentModelOld.create(**RAW.attributes).save()
     queryset = DocumentModel.objects(docID=RAW['docID'], source=RAW['source'])
     assert len(queryset) == 0

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -94,6 +94,7 @@ def test_renormalize():
 
 @pytest.mark.cassandra
 def test_migrate_v2():
+    RAW['doc'] = str(RAW['doc'])
     DocumentModelOld.create(**RAW.attributes).save()
     queryset = DocumentModel.objects(docID=RAW['docID'], source=RAW['source'])
     assert len(queryset) == 0

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -28,7 +28,7 @@ def raw_doc():
 def raw_docs():
     return [
         RawDocument({
-            'doc': six.binary_type(x),
+            'doc': str(x).encode('utf-8'),
             'docID': six.text_type(x),
             'source': u'test',
             'filetype': u'xml',

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,120 @@
+from __future__ import unicode_literals
+
+import copy
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from scrapi.linter import NormalizedDocument
+
+
+class TestValidation(object):
+
+    def test_validate_with_clean(self):
+        expected = {
+            "description": "This is a  test",
+            "contributors": [
+               {
+                    "name": "Test Testerson Jr",
+                    "givenName": "Test",
+                    "familyName": "Testerson",
+                    "additionalName": "",
+                    "ORCID": None,
+                    "email": ""
+                }
+            ],
+            'title': '',
+            'subjects': ['Math'],
+            'uris': {
+                "canonicalUri": "http://example.com"
+            },
+            "providerUpdatedDateTime": "2015-02-02T00:00:00Z",
+            "shareProperties": {
+                "source": "test"
+            }
+        }
+        doc = NormalizedDocument(to_be_validated, clean=True)
+        assert doc.attributes == expected
+
+
+    def test_validate(self):
+        expected = {
+            "description": "This is a  test",
+            "contributors": [
+                {
+                    "name": "Test Testerson Jr",
+                    "givenName": "Test",
+                    "familyName": "Testerson",
+                    "additionalName": "",
+                    "ORCID": None,
+                    "email": ""
+                }
+            ],
+            'title': '',
+            'tags': ['', '', ''],
+            'subjects': ['', 'Math'],
+            'uris': {
+                "canonicalUri": "http://example.com"
+            },
+            "providerUpdatedDateTime": "2015-02-02T00:00:00Z",
+            "shareProperties": {
+                "source": "test"
+            },
+            "otherProperties": [
+                {
+                    "name": "Empty2",
+                    "properties": {
+                        "Empty2": None
+                    }
+                }
+            ]
+        }
+        doc = NormalizedDocument(to_be_validated)
+        assert doc.attributes == expected
+
+
+    def test_validate_fails(self):
+        to_be_tested = copy.deepcopy(to_be_validated)
+        to_be_tested['providerUpdatedDateTime'] = 'Yesterday'
+        with pytest.raises(ValidationError) as e:
+            doc = NormalizedDocument(to_be_tested)
+
+        with pytest.raises(ValidationError) as e:
+            doc = NormalizedDocument(to_be_tested, validate=False)
+            doc.validate()
+
+
+
+to_be_validated = {
+    "description": "This is a  test",
+    "contributors": [
+        {
+            "name": "Test Testerson Jr",
+            "givenName": "Test",
+            "familyName": "Testerson",
+            "additionalName": "",
+            "ORCID": None,
+            "email": ""
+        }
+    ],
+    'title': '',
+    'tags': ['', '', ''],
+    'subjects': ['', 'Math'],
+    'uris': {
+        "canonicalUri": "http://example.com"
+    },
+    "providerUpdatedDateTime": "2015-02-02T00:00:00Z",
+    "shareProperties": {
+        "source": "test"
+    },
+    "otherProperties": [
+        {
+            "name": "Empty2",
+            "properties": {
+                "Empty2": None
+            }
+        }
+    ]
+}
+
+

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -19,8 +19,7 @@ class TestValidation(object):
                     "givenName": "Test",
                     "familyName": "Testerson",
                     "additionalName": "",
-                    "ORCID": None,
-                    "email": ""
+                    "sameAs": [],
                 }
             ],
             'title': '',
@@ -46,8 +45,7 @@ class TestValidation(object):
                     "givenName": "Test",
                     "familyName": "Testerson",
                     "additionalName": "",
-                    "ORCID": None,
-                    "email": ""
+                    "sameAs": []
                 }
             ],
             'title': '',
@@ -93,8 +91,7 @@ to_be_validated = {
             "givenName": "Test",
             "familyName": "Testerson",
             "additionalName": "",
-            "ORCID": None,
-            "email": ""
+            "sameAs": [],
         }
     ],
     'title': '',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -25,7 +25,7 @@ NORMALIZED_DOC = {
     'title': 'No',
     'contributors': [{'name': ''}],
     'source': 'test',
-    'providerUpdatedDateTime': '2014-04-04T00:00:00',
+    'providerUpdatedDateTime': '2014-04-04T00:00:00Z',
     'uris': {
         'canonicalUri': 'http://example.com/direct'
     }
@@ -62,7 +62,7 @@ RECORD = {
             the dietary patterns of eight free-ranging vervet monkey\
             (Chlorocebus pygerythrus) groups in South Africa using stable\
             isotope analysis.',
-    'providerUpdatedDateTime': '2015-02-23T00:00:00',
+    'providerUpdatedDateTime': '2015-02-23T00:00:00Z',
     'shareProperties': {
         'source': 'test'
     }

--- a/tests/vcr/osf.yaml
+++ b/tests/vcr/osf.yaml
@@ -7,31 +7,30 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: https://osf.io:443/api/v1/search/?q=category:registration%20%20AND%20date_created:[2015-04-22%20TO%202015-04-23]%20AND%20NOT%20title=test%20AND%20NOT%20title=%22Test%20Project%22&size=1000
+    uri: https://osf.io:443/api/v1/search/?q=category:registration%20%20AND%20registered_date:[2015-03-04%20TO%202015-03-06]%20AND%20NOT%20title=test%20AND%20NOT%20title=%22Test%20Project%22&size=1000
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+VWTW/bMAz9K4Iuu6yJYydN49uQbcV6GtrsNAyBIjO2GldyJXqZW/S/j5ITNGkS
-        bOj6AXQnyzRNPfKRT7rlqK6ApyzqRPF7xqWpNTp6v+VoUJS0GpLZQq4cWoHKaG+6Ixs2FXwolXDQ
-        +lfWXIJE+sy/tkvHvdsqDJ+ERdjjqjIadHAdr1+Cc+3Aeus3egbDg435+QYQxz0MC64uA+TvtzwD
-        J62qVjD5WDQlNCy3oiocAy1NBgwLYGLms5HI6FFLrC0wM2eCPE1dddikAEdOZAVXgVSiLBtG2DKm
-        NLNQ0Z4EP1TDhzO26bSJabRqVqMh8AFPbX0Fedfmsj/qep95XZZahJITPOXhvfNP9459KtWNmAEW
-        7LPCmxysKDN+98PXUOQhoF9XBEvjFBWWPoimeL6mAiEnHD7sVs3o21It1LRUehGgjGb5QnS9LeBZ
-        x1nX6jTUKnCxwt7+4C3KTTe5m4vSAZkz2nvabgoWsntQ5P+AP6q2/2OVQ7vDKoMQRVqghw/B46g3
-        OIr6R3E86fXTeJQmUac37EdR5Gl/SPW6DOYQA4WDZrDLgKktauLggjrDzsDmbfB17pDNTpqdv85M
-        IbQWbGwKQ/MQ4GzlskkyjYgEdibkwnnfp6azsguo99D5UaDYZLH1ez0Wk0lvmCZx2ht0BiejAyzy
-        LzpTP1VWi5JRj6CSqhIamUK4Yl59NM2B7/aDNGeL6wR3CLtAqIgyBWwsaF6t0sBOjckKWD49IzrB
-        Qu1hhESFEXAJFfr8ZA2UDqO2FzPS0JSd+84PqTo2NzbolMM6a7w0+RelkTRBBtUhmVgCaFYKndci
-        J7HSGROIJA1eojfGt4XzmsRHvbQfp/FJZ5gcHyD+j+P79LzyF+bj7xV6cK2zyz0NdGA4VnMRegaE
-        LEILbXZAG29PB6zU+B/1m3fvW+ygiCcT3wVJGh13el7DHyfi/1MXDHM92yfsj+2CNt4zdsGva5TL
-        IL3P3AVv9Sg/bkbzfYyP6W6yOc+t3x4mX+hCtj7K434n6Q8OzPKbOMrblt69K7/w0bG+jd5P2Ovc
-        xFsR3zrKt66zd78Bo8EIA04OAAA=
+        H4sIAAAAAAAAA81WXW/TMBT9K1aeQOpHkjbtmreBigBRaYLCAzBFXnLTmjh2sJ123bT/zrWTSsnK
+        JBBj8BT3+trX95zj4956hpXgxcQf+YsB8VJZC6Px961npKEcRxMMK9gwbRQ1TAobusOYOVRwzhnV
+        0ORXSn6D1OC0d9EMtWfT2m28tRu4GmUlBQiX+vL4wyXXGpSNfsSvC9wr7L3vHER79hgKdM3dkb/c
+        eik1sJHqYPfoLcVEphMF2ENqIMP5nHINGN6zgiWcicKuGc+vtzfl2MbGzVGFUeyqNhKP4yrUymLi
+        jQ+p2E1cTl5zLqgD0ftEBWhNyYsa0q3AXu4uLQTMcDe93gLZS5WRr3XoB6mCzA0yQkVGRF2CYimp
+        QOVSlVSkEJNzoqDiDPtC5Ak1BsrKEJmTdyzdGhA58GxAVpSBGpAl50yagdvtAgpViwEJfX9Bni2v
+        q5El8u3yw8VzB3TbRtOvjVQgMiY2CZRXVG1kB6E2kmBCkiHAnSlDNw4X2yXi22X2iK9ILJo2y8ck
+        ux5psGoCbN+CggBEQ38y9GfrIIjDMA7no1mI5/a7x2qpa/R33LuiCmWUHPEVyITtpIk2LbYxVxcB
+        x0+/aLQO5vHUj/3pKFhEbVEnlZ7ijaqtWDLQqWJVew08K8BHEF1pIFr8NdG9lFyqZCUN20GX+qbq
+        f0S9JSIcRVHwRNSHa/8sDqM4mI/CaPpvqA/Zvoh+hfrvYnuYn/jNa4qOiV4gGiUeb/XNbgLFSfKS
+        AxVSkRXjaNlOuscFs1Tl0cmCFXoMBU7eiBu0oK3prymy65844GcJ5JVC88Ir3ze/FVoiFUyXmtQi
+        A8UPaDdEA8+HqUSblZygOzOB0a5MG4T+WKZet5DdDd8JkqG3grvMNlDiFZHCPTtMoD3t0Fvs3KOY
+        G/pMGE9Cq/CZP3sKhYdDf7oOFnGAIp+MZouz31T4OcllrYZ7gKLPUhccok2dHUYt1e1rcOsV4J7g
+        E4wzmeIjgX8xcDZwCjxmdsB/MKnHinXjh3a7z3U/8fLuBzTEBzH2CAAA
     headers:
       cache-control: [private]
       connection: [close]
       content-encoding: [gzip]
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 24 Apr 2015 15:00:32 GMT']
+      date: ['Thu, 13 Aug 2015 15:01:29 GMT']
       server: [nginx/1.4.6 (Ubuntu)]
       set-cookie: [NB_SRVID=srv25533; path=/]
       transfer-encoding: [chunked]
@@ -45,18 +44,20 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: https://osf.io:443/api/v1/search/?q=category:registration%20%20AND%20date_created:[2015-04-22%20TO%202015-04-23]%20AND%20NOT%20title=test%20AND%20NOT%20title=%22Test%20Project%22&size=1000&from=1000
+    uri: https://osf.io:443/api/v1/search/?q=category:registration%20%20AND%20registered_date:[2015-03-04%20TO%202015-03-06]%20AND%20NOT%20title=test%20AND%20NOT%20title=%22Test%20Project%22&size=1000&from=1000
   response:
-    body: {string: !!python/unicode '{"time": 0.01, "counts": {"total": 7, "registration":
-        7}, "typeAliases": {"project": "Projects", "total": "Total", "component":
+    body: {string: !!python/unicode '{"time": 0.12, "counts": {"total": 3, "registration":
+        3}, "typeAliases": {"project": "Projects", "total": "Total", "component":
         "Components", "user": "Users", "registration": "Registrations"}, "results":
-        [], "tags": []}'}
+        [], "tags": [{"key": "ego depletion", "doc_count": 1}, {"key": "emotions",
+        "doc_count": 1}, {"key": "intervention", "doc_count": 1}, {"key": "self-control",
+        "doc_count": 1}]}'}
     headers:
       cache-control: [private]
       connection: [close]
-      content-length: ['219']
+      content-length: ['378']
       content-type: [application/json; charset=utf-8]
-      date: ['Fri, 24 Apr 2015 15:00:32 GMT']
+      date: ['Thu, 13 Aug 2015 15:01:29 GMT']
       server: [nginx/1.4.6 (Ubuntu)]
       set-cookie: [NB_SRVID=srv25533; path=/]
       x-sentry-id: [None]


### PR DESCRIPTION
Makes validation much stricter. Datetimes must have, timezone information, email addresses cannot be empty strings. Also adds an optional step before validation, where falsey leaf values that are not required are stripped out of the document. This allows you to default to null values in non-required field without getting the null value validation errors. Also update all harvesters to conform. Ready for review, @erinspace 

P.S. Also stripped whitespace off the normalized.json, just couldn't take it anymore.