### PR TITLE
Update datacite Cannonical uri harvesting

### DIFF
--- a/scrapi/harvesters/datacite.py
+++ b/scrapi/harvesters/datacite.py
@@ -23,7 +23,7 @@ class DataciteHarvester(OAIHarvester):
         return updated_schema(self._schema, {
             "description": ("//dc:description/node()", get_second_description),
             "uris": {
-                "canonicalUri": ('//dc:identifier/node()', oai_extract_dois),
+                "canonicalUri": ('//dc:identifier/node()', lambda x: oai_extract_dois(x)[0]),
                 "objectUris": ('//dc:identifier/node()', oai_extract_dois)
             }
         })

--- a/scrapi/harvesters/datacite.py
+++ b/scrapi/harvesters/datacite.py
@@ -6,7 +6,7 @@ Example API call: http://oai.datacite.org/oai?verb=ListRecords&metadataPrefix=oa
 from __future__ import unicode_literals
 
 from scrapi.base import OAIHarvester
-from scrapi.base.helpers import updated_schema, oai_extract_dois
+from scrapi.base.helpers import updated_schema, oai_extract_dois, compose, single_result
 
 
 class DataciteHarvester(OAIHarvester):
@@ -23,7 +23,7 @@ class DataciteHarvester(OAIHarvester):
         return updated_schema(self._schema, {
             "description": ("//dc:description/node()", get_second_description),
             "uris": {
-                "canonicalUri": ('//dc:identifier/node()', lambda x: oai_extract_dois(x)[0]),
+                "canonicalUri": ('//dc:identifier/node()', compose(single_result, oai_extract_dois)),
                 "objectUris": ('//dc:identifier/node()', oai_extract_dois)
             }
         })


### PR DESCRIPTION
Previously, datacite was saving a list in the cannnonical URI field, instead of a single element.  This makes the result a single string, no matter what!