### PR TITLE
Fix errors in repr when serializing for fluentd

### DIFF
--- a/scrapi/linter/document.py
+++ b/scrapi/linter/document.py
@@ -129,7 +129,7 @@ class NormalizedDocument(BaseDocument):
 
     def __repr__(self):
         return "NormalizedDocument(source='{}', url='{}', providerUpdatedDateTime='{}', ...)".format(
-            self.attributes['shareProperties']['source'],
-            self.attributes['uris']['canonicalUri'],
-            self.attributes['providerUpdatedDateTime']
+            self.attributes.get('shareProperties', {}).get('source'),
+            self.attributes.get('uris', {}).get('canonicalUri'),
+            self.attributes.get('providerUpdatedDateTime')
         )

--- a/scrapi/linter/document.py
+++ b/scrapi/linter/document.py
@@ -119,7 +119,11 @@ class RawDocument(BaseDocument):
         }
 
     def __repr__(self):
-        return "RawDocument(source='{source}', docID='{docID}, filetype='{filetype}, ...)".format(**self.attributes)
+        return "RawDocument(source='{source}', docID='{docID}', filetype='{filetype}', ...)".format(
+            source=self.attributes.get('source'),
+            docID=self.attributes.get('docID'),
+            filetype=self.attributes.get('filetype')
+        )
 
 
 class NormalizedDocument(BaseDocument):


### PR DESCRIPTION
noticed this popping up for some harvesters, now use .get instead of direct access in repr for normalized document