### PR TITLE
[feature] update pubmedcentral OAI-PMH endpoint

### DIFF
--- a/scrapi/harvesters/pubmedcentral.py
+++ b/scrapi/harvesters/pubmedcentral.py
@@ -1,7 +1,7 @@
 """
 Harvester of PubMed Central for the SHARE notification service
 
-Example API call: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&metadataPrefix=oai_dc&from=2015-04-13&until=2015-04-14
+Example API call: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&metadataPrefix=oai_dc&from=2015-04-13&until=2015-04-14
 """
 
 
@@ -29,7 +29,7 @@ class PubMedCentralHarvester(OAIHarvester):
             }
         })
 
-    base_url = 'http://www.pubmedcentral.nih.gov/oai/oai.cgi'
+    base_url = 'http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi'
     property_list = [
         'type', 'source', 'rights',
         'format', 'setSpec', 'date', 'identifier'

--- a/tests/vcr/pubmedcentral.yaml
+++ b/tests/vcr/pubmedcentral.yaml
@@ -7,7 +7,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&metadataPrefix=oai_dc&from=2014-12-24&until=2014-12-25
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&metadataPrefix=oai_dc&from=2014-12-24&until=2014-12-25
   response:
     body:
       string: !!binary |
@@ -208,7 +208,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4078828!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4078828!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -655,7 +655,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4213981!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4213981!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -1226,7 +1226,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4261833!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4261833!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -1653,7 +1653,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4265778!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4265778!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -2301,7 +2301,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4270036!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4270036!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -2885,7 +2885,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4270362!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4270362!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -3219,7 +3219,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4271001!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4271001!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -3437,7 +3437,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4271406!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4271406!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -3987,7 +3987,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4273043!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4273043!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -4503,7 +4503,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4274337!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4274337!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -4944,7 +4944,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4274696!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4274696!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -5205,7 +5205,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4275197!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4275197!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -5509,7 +5509,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4275702!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4275702!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -5894,7 +5894,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4275952!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4275952!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -6179,7 +6179,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4276075!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4276075!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |
@@ -6561,7 +6561,7 @@ interactions:
       Connection: [keep-alive]
       User-Agent: [python-requests/2.4.1 CPython/2.7.9 Darwin/14.0.0]
     method: GET
-    uri: http://www.pubmedcentral.nih.gov/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4276316!2014-12-24!2014-12-25!oai_dc!
+    uri: http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi?verb=ListRecords&resumptionToken=oai%3Apubmedcentral.nih.gov%3A4276316!2014-12-24!2014-12-25!oai_dc!
   response:
     body:
       string: !!binary |


### PR DESCRIPTION
The original pubmedcentral OAI-PMH url:

  http://www.pubmedcentral.nih.gov/oai/oai.cgi

...now returns a permanent redirect to a new url base:

  http://www.ncbi.nlm.nih.gov/pmc/oai/oai.cgi

This commit updates the harvester and the tests with the new url.  The
tests were updated with a search-and-replace. All pass without further
modification.